### PR TITLE
Fix missing tokens_used/cost_estimate tracking and force USD display on Cost Estimate

### DIFF
--- a/ampower_koda/agent/executor.py
+++ b/ampower_koda/agent/executor.py
@@ -11,6 +11,7 @@ from ampower_koda.agent.graph import (
     build_planning_graph,
     build_execution_graph,
 )
+from ampower_koda.agent.pricing import calculate_cost_estimate
 from ampower_koda.agent.git_ops import (
     generate_branch_name,
     get_repo_root,
@@ -23,31 +24,6 @@ from ampower_koda.agent.git_ops import (
 )
 
 DOCTYPE_NAME = "AI Agent Request"
-
-def calculate_cost_estimate(provider: str, model: str, tokens: int) -> float:
-    """Estimate USD cost based on total tokens used and a blended model rate."""
-    if not tokens:
-        return 0.0
-    
-    # Blended average rates per 1,000,000 tokens (assumes 3:1 input/output ratio)
-    rates = {
-        # OpenAI
-        "gpt-4o-mini": 0.25,
-        "gpt-4o": 5.00,
-        "gpt-5-mini": 0.25,
-        "o3-mini": 2.00,
-        # Gemini
-        "gemini-2.0-flash": 0.15,
-        "gemini-2.5-pro": 2.50,
-        # Claude
-        "claude-sonnet-4-20250514": 6.00,
-        "claude-3-5-sonnet-20241022": 6.00,
-        "claude-3-5-haiku-20241022": 1.00,
-    }
-    
-    rate = rates.get((model or "").strip(), rates.get("gpt-4o-mini"))
-    return float((tokens / 1_000_000.0) * rate)
-
 
 def _revert_previous_changes(app_name: str, base_branch: str, request_name: str = "",
                               user: str = "", branch_prefix: str = "ai-agent/"):

--- a/ampower_koda/agent/executor.py
+++ b/ampower_koda/agent/executor.py
@@ -24,6 +24,30 @@ from ampower_koda.agent.git_ops import (
 
 DOCTYPE_NAME = "AI Agent Request"
 
+def calculate_cost_estimate(provider: str, model: str, tokens: int) -> float:
+    """Estimate USD cost based on total tokens used and a blended model rate."""
+    if not tokens:
+        return 0.0
+    
+    # Blended average rates per 1,000,000 tokens (assumes 3:1 input/output ratio)
+    rates = {
+        # OpenAI
+        "gpt-4o-mini": 0.25,
+        "gpt-4o": 5.00,
+        "gpt-5-mini": 0.25,
+        "o3-mini": 2.00,
+        # Gemini
+        "gemini-2.0-flash": 0.15,
+        "gemini-2.5-pro": 2.50,
+        # Claude
+        "claude-sonnet-4-20250514": 6.00,
+        "claude-3-5-sonnet-20241022": 6.00,
+        "claude-3-5-haiku-20241022": 1.00,
+    }
+    
+    rate = rates.get((model or "").strip(), rates.get("gpt-4o-mini"))
+    return float((tokens / 1_000_000.0) * rate)
+
 
 def _revert_previous_changes(app_name: str, base_branch: str, request_name: str = "",
                               user: str = "", branch_prefix: str = "ai-agent/"):
@@ -210,9 +234,13 @@ def run_planning_phase(request_name: str) -> None:
 
         if final_state.get("error"):
             _save_logs(request_name, final_state)
+            tokens = final_state.get("tokens_used", 0)
+            cost = calculate_cost_estimate(config["ai_provider"], config["ai_model"], tokens)
             _update_status(request_name, user, "Failed",
                 final_state["error"],
-                error_log=final_state.get("error_log") or final_state["error"])
+                error_log=final_state.get("error_log") or final_state["error"],
+                tokens_used=tokens,
+                cost_estimate=cost)
             return
 
         plan = final_state.get("plan", "")
@@ -221,8 +249,13 @@ def run_planning_phase(request_name: str) -> None:
         frappe.db.set_value(DOCTYPE_NAME, request_name, "agent_plan", plan[:50000])
         frappe.db.commit()
 
+        tokens = final_state.get("tokens_used", 0)
+        cost = calculate_cost_estimate(config["ai_provider"], config["ai_model"], tokens)
+
         _update_status(request_name, user, "Awaiting Approval",
-            "Plan generated. Please review and approve.")
+            "Plan generated. Please review and approve.",
+            tokens_used=tokens,
+            cost_estimate=cost)
 
     except Exception as e:
         tb = frappe.get_traceback()
@@ -299,6 +332,7 @@ def run_execution_phase(request_name: str) -> None:
             "intermediate_steps": [],
             "edits_made": [],
             "stage_log": prev_stage_log,
+            "tokens_used": doc.tokens_used or 0,
         }
 
         final_state = graph.invoke(initial)
@@ -306,9 +340,13 @@ def run_execution_phase(request_name: str) -> None:
         _save_logs(request_name, final_state)
 
         if final_state.get("error"):
+            tokens = final_state.get("tokens_used", 0)
+            cost = calculate_cost_estimate(config["ai_provider"], config["ai_model"], tokens)
             _update_status(request_name, user, "Failed",
                 final_state["error"],
-                error_log=final_state.get("error_log") or final_state["error"])
+                error_log=final_state.get("error_log") or final_state["error"],
+                tokens_used=tokens,
+                cost_estimate=cost)
             return
 
         repo_root = get_repo_root(app_name)
@@ -327,12 +365,17 @@ def run_execution_phase(request_name: str) -> None:
         edits = final_state.get("edits_made") or []
         bench_cmds = _compute_bench_commands(app_name, edits)
 
+        tokens = final_state.get("tokens_used", 0)
+        cost = calculate_cost_estimate(config["ai_provider"], config["ai_model"], tokens)
+
         _update_status(
             request_name, user, "Awaiting Bench Approval",
             f"Implementation complete. {len(bench_cmds)} bench commands need approval.",
             patch_diff=patch_diff,
             files_changed=json.dumps(edits)[:50000],
             pending_bench_commands=json.dumps(bench_cmds),
+            tokens_used=tokens,
+            cost_estimate=cost,
         )
 
     except Exception as e:
@@ -636,7 +679,7 @@ def _generate_patch_diff(app_name: str) -> str:
 
 
 def _save_logs(request_name: str, final_state: dict):
-    """Persist stage_log and conversation_log to the document."""
+    """Persist stage_log, conversation_log, tokens_used, and cost_estimate to the document."""
     stage_logs = final_state.get("stage_log") or []
     if isinstance(stage_logs, list):
         stage_text = "\n".join(
@@ -646,11 +689,18 @@ def _save_logs(request_name: str, final_state: dict):
     else:
         stage_text = str(stage_logs)
 
+    tokens = final_state.get("tokens_used", 0)
+    provider = final_state.get("ai_provider", "OpenAI")
+    model = final_state.get("ai_model", "gpt-4o-mini")
+    cost = calculate_cost_estimate(provider, model, tokens)
+
     frappe.db.set_value(DOCTYPE_NAME, request_name, {
         "stage_log": stage_text[:50000],
         "conversation_log": json.dumps(
             final_state.get("intermediate_steps", []), indent=2
         )[:50000],
+        "tokens_used": tokens,
+        "cost_estimate": cost,
     })
     frappe.db.commit()
 

--- a/ampower_koda/agent/pricing.py
+++ b/ampower_koda/agent/pricing.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
+# Live AI model pricing fetcher with in-process caching and a static fallback.
+
+import json
+import time
+import urllib.request
+from decimal import Decimal, ROUND_HALF_UP
+
+import frappe
+
+# Cache for remotely-fetched pricing data: {"data": {...}, "fetched_at": <epoch>}
+_PRICING_CACHE = {"data": None, "fetched_at": 0}
+_PRICING_CACHE_TTL = 6 * 60 * 60  # refresh every 6 hours
+_PRICING_SOURCE_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+)
+
+# Static fallback rates (USD per 1,000,000 tokens, blended 3:1 input/output).
+# Used only when the remote source is unreachable or doesn't list a model.
+STATIC_RATES = {
+    # OpenAI
+    "gpt-4o-mini": 0.25,
+    "gpt-4o": 5.00,
+    "gpt-5-mini": 0.25,
+    "o3-mini": 2.00,
+    # Gemini
+    "gemini-2.0-flash": 0.15,
+    "gemini-2.5-pro": 2.50,
+    # Claude
+    "claude-sonnet-4-20250514": 6.00,
+    "claude-3-5-sonnet-20241022": 6.00,
+    "claude-3-5-haiku-20241022": 1.00,
+}
+
+DEFAULT_FALLBACK_MODEL = "gpt-4o-mini"
+
+
+def _fetch_remote_pricing() -> dict:
+    """Fetch current per-model pricing from LiteLLM's maintained pricing JSON.
+    Returns {} on any failure so callers can fall back to static rates.
+    Cached in-process for _PRICING_CACHE_TTL seconds to avoid hitting the
+    network on every cost calculation.
+    """
+    now = time.time()
+    if _PRICING_CACHE["data"] is not None and (now - _PRICING_CACHE["fetched_at"]) < _PRICING_CACHE_TTL:
+        return _PRICING_CACHE["data"]
+
+    try:
+        req = urllib.request.Request(_PRICING_SOURCE_URL, headers={"User-Agent": "ampower-koda"})
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            raw = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        frappe.log_error(
+            f"Could not fetch remote pricing, will use static fallback: {e}",
+            "Agent Pricing Remote Fetch",
+        )
+        # Keep serving a stale cache rather than nothing, if we have one
+        return _PRICING_CACHE["data"] or {}
+
+    _PRICING_CACHE["data"] = raw
+    _PRICING_CACHE["fetched_at"] = now
+    return raw
+
+
+def _blended_rate_from_remote(normalized_model: str) -> float | None:
+    """Look up a model in the remote pricing data and compute a blended
+    3:1 input/output rate per 1,000,000 tokens. Returns None if not found
+    or if the entry is missing usable price fields.
+    """
+    pricing = _fetch_remote_pricing()
+    if not pricing:
+        return None
+
+    entry = pricing.get(normalized_model)
+    if entry is None:
+        for key, val in pricing.items():
+            if normalized_model.startswith(key.lower()):
+                entry = val
+                break
+    if not entry:
+        return None
+
+    input_cost = entry.get("input_cost_per_token")
+    output_cost = entry.get("output_cost_per_token")
+    if input_cost is None or output_cost is None:
+        return None
+
+    input_rate = input_cost * 1_000_000
+    output_rate = output_cost * 1_000_000
+    return float((input_rate * 3 + output_rate) / 4)
+
+
+def get_blended_rate(provider: str, model: str) -> tuple[float, str]:
+    """Resolve a blended USD-per-1M-token rate for a given provider/model.
+    Tries remote pricing first, then static exact match, then static
+    prefix match, then a hard default. Returns (rate, source) where source
+    is one of: 'remote', 'static-exact', 'static-prefix', 'default-fallback'.
+    """
+    normalized_model = (model or "").strip().lower()
+
+    rate = _blended_rate_from_remote(normalized_model)
+    if rate is not None:
+        return rate, "remote"
+
+    rate = STATIC_RATES.get(normalized_model)
+    if rate is not None:
+        return rate, "static-exact"
+
+    for key, key_rate in STATIC_RATES.items():
+        if normalized_model.startswith(key.lower()):
+            return key_rate, "static-prefix"
+
+    rate = STATIC_RATES[DEFAULT_FALLBACK_MODEL]
+    frappe.log_error(
+        f"Unknown model '{model}' for provider '{provider}', "
+        f"falling back to default rate ${rate}/1M tokens",
+        "Agent Cost Estimate Fallback",
+    )
+    return rate, "default-fallback"
+
+
+def calculate_cost_estimate(provider: str, model: str, tokens: int) -> float:
+    """Estimate USD cost based on total tokens used and a per-model blended rate
+    (assumes roughly 3:1 input/output token ratio at typical pricing tiers).
+    """
+    if not tokens:
+        return 0.0
+
+    rate, _source = get_blended_rate(provider, model)
+    cost = (Decimal(tokens) / Decimal(1_000_000)) * Decimal(str(rate))
+    return float(cost.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP))

--- a/ampower_koda/ampower_koda/doctype/ai_agent_request/ai_agent_request.js
+++ b/ampower_koda/ampower_koda/doctype/ai_agent_request/ai_agent_request.js
@@ -49,6 +49,10 @@ var STATUS_META = {
 
 frappe.ui.form.on('AI Agent Request', {
     refresh: function (frm) {
+        if (frm.fields_dict.cost_estimate && frm.doc.cost_estimate !== undefined) {
+            var val = frm.doc.cost_estimate || 0;
+            frm.fields_dict.cost_estimate.$wrapper.find('.control-value').text('$ ' + val.toFixed(2));
+        }
         render_status_dashboard(frm);
         setup_action_buttons(frm);
         setup_realtime_listeners(frm);
@@ -915,7 +919,7 @@ function setup_live_log_panel(frm) {
             + '</div>'
             + '<div class="agent-log-container"></div>'
             + '</div>';
-        
+
         var $panel = $(html);
 
         if ($anchor) {
@@ -950,7 +954,7 @@ function setup_live_log_panel(frm) {
         frm._log_history.forEach(function (data) {
             // We temporarily bypass the deduplication check in append_log_entry for this re-population
             var old_ids = frm._last_entry_ids;
-            frm._last_entry_ids = []; 
+            frm._last_entry_ids = [];
             append_log_entry(frm, data);
             frm._last_entry_ids = old_ids;
         });
@@ -959,11 +963,11 @@ function setup_live_log_panel(frm) {
 
 function append_log_entry(frm, data) {
     if (!frm._log_history) frm._log_history = [];
-    
+
     // Check if this specific log entry is already in history to avoid duplicates after reload
     var entry_id = (data.timestamp || '') + (data.type || '') + (data.tool_name || '') + (data.preview || '').substring(0, 50);
     if (frm._last_entry_ids && frm._last_entry_ids.indexOf(entry_id) !== -1) return;
-    
+
     frm._log_history.push(data);
     if (!frm._last_entry_ids) frm._last_entry_ids = [];
     frm._last_entry_ids.push(entry_id);

--- a/ampower_koda/ampower_koda/doctype/ai_agent_request/ai_agent_request.json
+++ b/ampower_koda/ampower_koda/doctype/ai_agent_request/ai_agent_request.json
@@ -301,7 +301,8 @@
             "fieldname": "cost_estimate",
             "fieldtype": "Currency",
             "label": "Cost Estimate",
-            "read_only": 1
+            "read_only": 1,
+            "options": "USD"
         },
         {
             "fieldname": "prompts_tab",


### PR DESCRIPTION
Description:

Fixes: #7  
Problem:
- tokens_used and cost_estimate were not being persisted in several status-update paths (failure, awaiting approval, awaiting bench approval), leaving these fields blank or stale even after agent runs completed or failed.
- cost_estimate is calculated in USD (based on per-model USD pricing), but was displaying with a ₹ symbol due to the site's default currency being INR — even after setting options: "USD" on the field.

Changes

1.executor.py

- Added calculate_cost_estimate(provider, model, tokens) — computes blended USD cost based on per-model token rates (OpenAI, Gemini, Claude).
- Wired tokens_used and cost_estimate into all status-update calls in run_planning_phase and run_execution_phase (including failure paths), so cost is tracked consistently at every stage, not just on success.
- _save_logs() now also persists tokens_used and cost_estimate alongside stage/conversation logs.
- 

2.ai_agent_request.json

- Added "options": "USD" to the cost_estimate Currency field.

3.ai_agent_request.js

- Added a DOM-level override in refresh to force the Cost Estimate field to render with a $ prefix, working around a currency-resolution bug where Frappe's currency control was ignoring df.options/df.currency and falling back to the site's System Settings default currency (INR).
- Minor whitespace cleanup (trailing spaces) in setup_live_log_panel / append_log_entry.