### PR TITLE
Koda v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Python dependencies :
 
 ## Setup
 
-1. Open AI Agent Settings from the search bar.
+1. Open Agent Settings from the search bar.
 2. Check Enable AI Agent.
 3. Enter your API key for the provider you want to use (OpenAI, Gemini, or Claude).
 4. Optionally set a default provider and model.
@@ -59,7 +59,7 @@ Each request goes through a multi-step pipeline with human approval gates. You c
 
 ## Creating a Request
 
-1. Go to AI Agent Request list (search for it or find it under the AI Agents module).
+1. Go to Agent Request list (search for it or find it under the AI Agents module).
 2. Click New.
 3. Fill in:
    - Title -- short summary of what you need.
@@ -74,7 +74,7 @@ Each request goes through a multi-step pipeline with human approval gates. You c
 5. Click Start Agent.
 
 ### Persistence
-The app remembers your most-used configuration (Target App Name, GitHub Repo URL, AI Provider, Model, Base Branch, Branch Prefix, Git identity) and pre-fills it on every new request. The GitHub token is never persisted across requests for security reasons you must enter it on each new request (or store it in AI Agent Settings as the encrypted default).
+The app remembers your most-used configuration (Target App Name, GitHub Repo URL, AI Provider, Model, Base Branch, Branch Prefix, Git identity) and pre-fills it on every new request. The GitHub token is never persisted across requests for security reasons you must enter it on each new request (or store it in Agent Settings as the encrypted default).
 
 ## Approval Steps
 
@@ -123,7 +123,7 @@ These fields (except the GitHub Token) are remembered across requests using user
 
 For advanced use cases, you can override the agent's default logic on a per-request basis:
 
-1. Open an **AI Agent Request**.
+1. Open an **Agent Request**.
 2. Go to the **Prompts** tab.
 3. Uncheck **Use Default Prompts**.
 4. In the **Custom Prompts** table, add one or more overrides:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ AI Coding Agent for Frappe apps. Describe a bug fix, feature request, or improve
 - **Live Monitoring**: Track agent progress in real-time with an auto-scrolling log console and visual status dashboard.
 - **Human-in-the-loop**: Full control over every phase. Review and edit implementation plans and bench commands before they run.
 - **Smart Exploration**: Powered by LangGraph, the agent performs deep codebase analysis to minimize hallucinations.
+- **Koda IDE**: Browse the changed files, edit code in a built-in editor, view diffs, and save, deploy, or push changes without leaving Frappe.
 - **Git Native**: Automatically manages branches and creates clean Pull Requests on GitHub.
 - **Multi-Model Support**: Choose between OpenAI, Google Gemini, or Anthropic Claude.
 
@@ -135,6 +136,19 @@ For advanced use cases, you can override the agent's default logic on a per-requ
 
 If a prompt type is not explicitly added to the table, the agent will fall back to its internal system default for that phase.
 
+## Koda IDE
+
+Once a request has an agent branch or a generated diff, open the **Koda IDE** from the Actions dropdown on the Agent Request (**Open Koda IDE**). The IDE lets you:
+
+- Browse the changed files in a file explorer, with change badges (added / modified / deleted).
+- Edit any file in a full code editor with syntax highlighting and a light/dark theme toggle.
+- Switch between **Code** and **Diff** views to inspect exactly what changed.
+- **Save** edits directly to the agent branch on disk.
+- **Deploy** the selected bench commands (migrate, build, clear-cache, restart).
+- **Push** the branch and create a pull request on GitHub.
+
+Open tabs can be closed via the close (×) control that appears on hover.
+
 ## Data Security
 
 Please note that we use LLMs, and the data (repositories) will be processed by an LLM. We do not consider this a data security concern, as this is how agentic workflows typically operate. To perform tasks on your data, the LLM must be able to access and read the relevant information. Appropriate security controls and data handling practices should still be followed to ensure the protection of sensitive information.
@@ -147,7 +161,7 @@ Please note that we use LLMs, and the data (repositories) will be processed by a
 
 ## In-App Help
 
-For more detailed guidance and tips, search for **AI Agents Help** in your Frappe search bar.
+For more detailed guidance and tips, search for **Koda Docs** in your Frappe search bar.
 
 ## License
 

--- a/ampower_koda/agent/api.py
+++ b/ampower_koda/agent/api.py
@@ -21,7 +21,6 @@ from ampower_koda.agent.git_ops import (
     run_git,
 )
 from ampower_koda.agent.graph import _get_bench_env
-from ampower_koda.agent.prompts import plan_has_open_questions
 
 DOCTYPE_NAME = "Agent Request"
 
@@ -90,6 +89,10 @@ def start_agent(request_name: str):
         "patch_diff": "",
         "conversation_log": "",
         "understanding_snapshot": "",
+        "change_summary": "",
+        # files_changed is a JSON column with a json_valid() CHECK constraint —
+        # "" is not valid JSON, so clear it with NULL (allowed) instead.
+        "files_changed": None,
     })
     frappe.db.commit()
 
@@ -205,12 +208,6 @@ def execute_existing_plan(request_name: str):
     if not (doc.agent_plan or "").strip():
         frappe.throw(_("No plan found for this request."))
 
-    if plan_has_open_questions(doc.agent_plan or ""):
-        frappe.throw(_(
-            "This plan has open questions in 'Questions for User'. "
-            "Resolve them before executing."
-        ))
-
     # Implementation can only start if we are at the approval stage or have finished a previous run.
     allowed = ("Awaiting Approval", "Failed", "Cancelled", "Completed", "Awaiting Push Approval")
     if doc.status not in allowed:
@@ -252,13 +249,6 @@ def approve_plan(request_name: str, edited_plan: str = None):
     plan_to_run = (edited_plan or doc.agent_plan or "").strip()
     if not plan_to_run:
         frappe.throw(_("No plan found for this request."))
-
-    if plan_has_open_questions(plan_to_run):
-        frappe.throw(_(
-            "This plan has open questions in 'Questions for User'. "
-            "Answer them in the request description, edit the plan to resolve them, "
-            "or replace that section with 'None — request is fully clear.' before approving."
-        ))
 
     if edited_plan is not None and edited_plan.strip():
         frappe.db.set_value(DOCTYPE_NAME, request_name, "agent_plan", edited_plan.strip()[:50000])

--- a/ampower_koda/agent/api.py
+++ b/ampower_koda/agent/api.py
@@ -8,10 +8,20 @@ import subprocess
 import frappe
 from frappe import _
 
-from ampower_koda.agent.git_ops import checkout_base
+from ampower_koda.agent import tools as agent_tools
+from ampower_koda.agent.executor import _generate_patch_diff
+from ampower_koda.agent.git_ops import (
+    branch_exists,
+    checkout_base,
+    diff_file,
+    get_current_branch,
+    get_repo_root,
+    list_changed_files,
+    run_git,
+)
 from ampower_koda.agent.graph import _get_bench_env
 
-DOCTYPE_NAME = "AI Agent Request"
+DOCTYPE_NAME = "Agent Request"
 
 
 def _validate_provider_key(doc):
@@ -19,9 +29,9 @@ def _validate_provider_key(doc):
     Verifies that the AI provider and its API key are correctly configured in settings.
     This check ensures the agent has its 'brain' ready before it attempts any work.
     """
-    settings = frappe.get_single("AI Agent Settings")
+    settings = frappe.get_single("Agent Settings")
     if not settings.enable_ai_agent:
-        frappe.throw(_("AI Coding Agent is disabled in AI Agent Settings."))
+        frappe.throw(_("AI Coding Agent is disabled in Agent Settings."))
     provider = (doc.ai_provider or settings.default_ai_provider or "OpenAI").strip()
     key_checks = {
         "OpenAI": ("openai_api_key", "OpenAI API key"),
@@ -30,7 +40,7 @@ def _validate_provider_key(doc):
     }
     field, label = key_checks.get(provider, key_checks["OpenAI"])
     if not getattr(settings, field, None):
-        frappe.throw(_("{0} is not set in AI Agent Settings.").format(label))
+        frappe.throw(_("{0} is not set in Agent Settings.").format(label))
 
 
 @frappe.whitelist()
@@ -71,6 +81,92 @@ def start_agent(request_name: str):
         request_name=request_name,
     )
     return {"status": "ok", "message": _("Planning phase started.")}
+
+
+@frappe.whitelist()
+def submit_follow_up(request_name: str, follow_up_message: str):
+    """
+    Append a user follow-up issue to existing context and run a surgical fix
+    on the same branch without restarting explore/plan.
+    """
+    if not request_name:
+        frappe.throw(_("Request name is required."))
+    if not (follow_up_message or "").strip():
+        frappe.throw(_("Follow-up message is required."))
+
+    doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    restartable = ("Queued", "Failed", "Cancelled", "Completed", "Awaiting Approval", "Awaiting Push Approval")
+    if doc.status not in restartable:
+        frappe.throw(_("Follow-up is allowed only when the agent is idle (status: {0}).").format(doc.status))
+    if not (doc.branch_name or "").strip():
+        frappe.throw(_("Follow-up fix needs an existing branch on this request."))
+
+    _validate_provider_key(doc)
+
+    base_request = (doc.user_message or "").strip()
+    follow_up = (follow_up_message or "").strip()
+
+    context_lines = []
+    if doc.status:
+        context_lines.append(f"- Previous status: {doc.status}")
+    if doc.branch_name:
+        context_lines.append(f"- Previous branch: {doc.branch_name}")
+    if doc.pr_url:
+        context_lines.append(f"- Previous PR: {doc.pr_url}")
+    if doc.error_log:
+        context_lines.append(f"- Previous error snapshot: {(doc.error_log or '')[:400]}")
+    context_text = "\n".join(context_lines) if context_lines else "- No additional run metadata recorded."
+
+    changed_paths = []
+    try:
+        for row in json.loads(doc.files_changed or "[]"):
+            p = (row or {}).get("path")
+            if p:
+                changed_paths.append(p)
+    except Exception:
+        pass
+    changed_hint = "\n".join(f"- {p}" for p in changed_paths[:20]) if changed_paths else "- (not recorded)"
+
+    merged_message = (
+        f"{base_request}\n\n"
+        "## FOLLOW-UP ISSUE AFTER USER TESTING\n"
+        f"{follow_up}\n\n"
+        "## CONTEXT FROM PREVIOUS RUN\n"
+        f"{context_text}\n\n"
+        "### Instructions for follow-up\n"
+        "- Fix the follow-up issue precisely.\n"
+        "- Keep all previously working functionality intact.\n"
+        "- Prefer surgical changes over broad rewrites.\n"
+    )
+    focused_plan = (
+        "Follow-up fix plan (same branch, no re-explore):\n"
+        "1) Reproduce the exact follow-up issue from USER REQUEST.\n"
+        "2) Inspect only the files directly related to the issue first.\n"
+        "3) Apply minimal targeted edits.\n"
+        "4) Run validate_code on changed .py/.js and verify no regressions in touched flows.\n"
+        "5) Report precise files changed and why.\n\n"
+        "Likely affected files from previous run:\n"
+        f"{changed_hint}"
+    )
+
+    frappe.db.set_value(DOCTYPE_NAME, request_name, {
+        "status": "Implementing",
+        "user_message": merged_message[:50000],
+        "agent_plan": focused_plan[:50000],
+        "error_log": "",
+        "bench_log": "",
+        "patch_diff": "",
+    })
+    frappe.db.commit()
+
+    frappe.enqueue(
+        "ampower_koda.agent.executor.run_execution_phase",
+        queue="default",
+        timeout=1800,
+        request_name=request_name,
+        preserve_branch=1,
+    )
+    return {"status": "ok", "message": _("Follow-up run started on existing branch (explore/plan skipped).")}
 
 
 @frappe.whitelist()
@@ -361,6 +457,373 @@ def get_agent_status(request_name: str):
         "bench_log": doc.bench_log,
         "patch_diff": doc.patch_diff,
     }
+
+
+_SKIP_TREE_DIRS = {".git", "__pycache__", "node_modules", ".venv", "dist", "build", ".mypy_cache"}
+_SKIP_TREE_SUFFIXES = (".pyc", ".pyo")
+
+
+def _parse_patch_diff_index(patch_diff: str) -> dict[str, str]:
+    """Build {relative_path: status} from a stored unified diff."""
+    changed: dict[str, str] = {}
+    if not patch_diff:
+        return changed
+
+    lines = patch_diff.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.startswith("--- "):
+            i += 1
+            continue
+
+        old_raw = line[4:].strip()
+        new_raw = ""
+        if i + 1 < len(lines) and lines[i + 1].startswith("+++ "):
+            new_raw = lines[i + 1][4:].strip()
+            i += 2
+        else:
+            i += 1
+            continue
+
+        if old_raw == "/dev/null" and new_raw.startswith("b/"):
+            changed[new_raw[2:]] = "A"
+        elif new_raw == "/dev/null" and old_raw.startswith("a/"):
+            changed[old_raw[2:]] = "D"
+        elif old_raw.startswith("a/") and new_raw.startswith("b/"):
+            changed[new_raw[2:]] = "M"
+        elif new_raw.startswith("b/"):
+            changed[new_raw[2:]] = "M"
+
+    return changed
+
+
+def _extract_file_diff_from_patch(patch_diff: str, file_path: str) -> str:
+    """Extract one file's diff block from combined patch_diff text."""
+    if not patch_diff or not file_path:
+        return ""
+
+    blocks = patch_diff.split("\n\n")
+    needle_a = f"--- a/{file_path}"
+    needle_null_old = "--- /dev/null"
+    needle_b = f"+++ b/{file_path}"
+
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        if needle_b in block and (needle_a in block or needle_null_old in block):
+            return block
+    return ""
+
+
+def _safe_repo_path(repo_root: str, file_path: str) -> str:
+    """Resolve file_path inside repo_root or throw on traversal."""
+    if not file_path or file_path.startswith("/") or ".." in file_path.split("/"):
+        frappe.throw(_("Invalid file path."))
+
+    full = os.path.normpath(os.path.join(repo_root, file_path))
+    root_norm = os.path.normpath(repo_root)
+    if not full.startswith(root_norm + os.sep) and full != root_norm:
+        frappe.throw(_("File path is outside the repository."))
+    return full
+
+
+def _write_repo_file(repo_root: str, file_path: str, content: str) -> str:
+    """Write content to a repo-relative path; return absolute path written."""
+    full = _safe_repo_path(repo_root, file_path)
+    parent = os.path.dirname(full)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(full, "w", encoding="utf-8") as f:
+        f.write(content)
+    return full
+
+
+def _should_skip_tree_entry(name: str) -> bool:
+    if name in _SKIP_TREE_DIRS:
+        return True
+    return any(name.endswith(suffix) for suffix in _SKIP_TREE_SUFFIXES)
+
+
+def _build_directory_tree(repo_root: str, changed: dict[str, str]) -> list[dict]:
+    """Walk repo_root and return nested tree nodes with change metadata."""
+
+    def walk(dir_path: str, rel_prefix: str) -> list[dict]:
+        nodes: list[dict] = []
+        try:
+            entries = sorted(os.listdir(dir_path))
+        except OSError:
+            return nodes
+
+        for name in entries:
+            if _should_skip_tree_entry(name):
+                continue
+
+            full = os.path.join(dir_path, name)
+            rel = f"{rel_prefix}/{name}" if rel_prefix else name
+
+            if os.path.isdir(full):
+                children = walk(full, rel)
+                changed_count = sum(
+                    1 for c in changed if c == rel or c.startswith(rel + "/")
+                )
+                nodes.append({
+                    "name": name,
+                    "type": "folder",
+                    "path": rel,
+                    "children": children,
+                    "changed_count": changed_count,
+                    "has_changes": changed_count > 0,
+                })
+            else:
+                status = changed.get(rel)
+                nodes.append({
+                    "name": name,
+                    "type": "file",
+                    "path": rel,
+                    "status": status,
+                    "has_changes": bool(status),
+                })
+
+        folders = [n for n in nodes if n["type"] == "folder"]
+        files = [n for n in nodes if n["type"] == "file"]
+        folders.sort(key=lambda n: n["name"].lower())
+        files.sort(key=lambda n: n["name"].lower())
+        return folders + files
+
+    return walk(repo_root, "")
+
+
+def _get_changed_files_for_request(doc) -> tuple[dict[str, str], str]:
+    """Return changed file map and data source ('git' or 'patch_diff')."""
+    app_name = (doc.target_app_name or "").strip()
+    base_branch = (doc.base_branch or "main").strip()
+    branch_name = (doc.branch_name or "").strip()
+
+    if app_name and branch_name and branch_exists(app_name, branch_name):
+        ok, files = list_changed_files(app_name, base_branch, branch_name)
+        if ok and files:
+            return {f["path"]: f["status"] for f in files}, "git"
+
+    patch_index = _parse_patch_diff_index(doc.patch_diff or "")
+    if patch_index:
+        return patch_index, "patch_diff"
+
+    if app_name and branch_name and branch_exists(app_name, branch_name):
+        ok, files = list_changed_files(app_name, base_branch, branch_name)
+        if ok:
+            return {f["path"]: f["status"] for f in files}, "git"
+
+    return {}, "none"
+
+
+@frappe.whitelist()
+def get_change_tree(request_name: str):
+    """Return full app directory tree with agent-modified files highlighted."""
+    if not request_name:
+        frappe.throw(_("Request name is required."))
+
+    doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    app_name = (doc.target_app_name or "").strip()
+    if not app_name:
+        frappe.throw(_("Target app is not set on this request."))
+
+    repo_root = get_repo_root(app_name)
+    changed, source = _get_changed_files_for_request(doc)
+    tree = _build_directory_tree(repo_root, changed)
+
+    pending_cmds = []
+    try:
+        pending_cmds = json.loads(doc.pending_bench_commands or "[]")
+    except Exception:
+        pass
+
+    return {
+        "request_name": doc.name,
+        "app_name": app_name,
+        "base_branch": (doc.base_branch or "main").strip(),
+        "branch_name": (doc.branch_name or "").strip(),
+        "source": source,
+        "changed": changed,
+        "tree": tree,
+        "totals": {"files": len(changed)},
+        "request": {
+            "status": doc.status,
+            "pr_url": doc.pr_url,
+            "pr_number": doc.pr_number,
+            "pending_bench_commands": pending_cmds,
+        },
+    }
+
+
+@frappe.whitelist()
+def get_file_diff(request_name: str, file_path: str):
+    """Return untruncated unified diff for one file in the agent's changes."""
+    if not request_name:
+        frappe.throw(_("Request name is required."))
+    if not file_path:
+        frappe.throw(_("File path is required."))
+
+    doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    app_name = (doc.target_app_name or "").strip()
+    if not app_name:
+        frappe.throw(_("Target app is not set on this request."))
+
+    repo_root = get_repo_root(app_name)
+    _safe_repo_path(repo_root, file_path)
+
+    base_branch = (doc.base_branch or "main").strip()
+    branch_name = (doc.branch_name or "").strip()
+    changed, source = _get_changed_files_for_request(doc)
+    status = changed.get(file_path, "")
+
+    diff_text = ""
+    if branch_name and branch_exists(app_name, branch_name):
+        ok, diff_text = diff_file(app_name, base_branch, branch_name, file_path)
+        if not ok:
+            diff_text = ""
+
+    if not diff_text.strip():
+        diff_text = _extract_file_diff_from_patch(doc.patch_diff or "", file_path)
+
+    return {
+        "path": file_path,
+        "status": status,
+        "source": source if diff_text else "none",
+        "diff": diff_text,
+    }
+
+
+def _detect_editor_language(file_path: str) -> str:
+    ext = os.path.splitext(file_path or "")[1].lower()
+    return {
+        ".py": "Python",
+        ".js": "Javascript",
+        ".json": "JSON",
+        ".html": "HTML",
+        ".css": "CSS",
+        ".md": "Markdown",
+    }.get(ext, "Text")
+
+
+def _ensure_agent_branch(doc) -> str:
+    """Checkout the request's agent branch before IDE file writes."""
+    app_name = (doc.target_app_name or "").strip()
+    branch_name = (doc.branch_name or "").strip()
+    if not app_name:
+        frappe.throw(_("Target app is not set on this request."))
+    if not branch_name:
+        frappe.throw(_("No agent branch found on this request."))
+
+    repo_root = get_repo_root(app_name)
+    current = get_current_branch(app_name)
+    if current != branch_name:
+        if not branch_exists(app_name, branch_name):
+            frappe.throw(_("Branch '{0}' was not found locally.").format(branch_name))
+        ok, out = run_git(["checkout", branch_name], cwd=repo_root)
+        if not ok:
+            frappe.throw(_("Could not checkout branch '{0}': {1}").format(branch_name, out))
+    return branch_name
+
+
+@frappe.whitelist()
+def get_file_content(request_name: str, file_path: str):
+    """Return full file content for the IDE editor."""
+    if not request_name:
+        frappe.throw(_("Request name is required."))
+    if not file_path:
+        frappe.throw(_("File path is required."))
+
+    doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    _ensure_agent_branch(doc)
+    app_name = (doc.target_app_name or "").strip()
+    if not app_name:
+        frappe.throw(_("Target app is not set on this request."))
+
+    repo_root = get_repo_root(app_name)
+    full = _safe_repo_path(repo_root, file_path)
+    if not os.path.isfile(full):
+        frappe.throw(_("File not found: {0}").format(file_path))
+
+    with open(full, "r", encoding="utf-8", errors="replace") as f:
+        content = f.read()
+
+    return {
+        "path": file_path,
+        "full_path": full,
+        "content": content,
+        "language": _detect_editor_language(file_path),
+    }
+
+
+@frappe.whitelist()
+def save_file_content(request_name: str, file_path: str, content: str):
+    """Save edited file content from the IDE to the agent branch working tree."""
+    if not request_name:
+        frappe.throw(_("Request name is required."))
+    if not file_path:
+        frappe.throw(_("File path is required."))
+    if content is None:
+        frappe.throw(_("File content is required."))
+
+    doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    _ensure_agent_branch(doc)
+    app_name = (doc.target_app_name or "").strip()
+
+    repo_root = get_repo_root(app_name)
+    full_path = _write_repo_file(repo_root, file_path, content)
+
+    patch_diff = _generate_patch_diff(app_name)
+    frappe.db.set_value(DOCTYPE_NAME, request_name, "patch_diff", patch_diff[:100000])
+    frappe.db.commit()
+
+    return {
+        "status": "ok",
+        "message": _("Saved {0} bytes to disk.").format(len(content)),
+        "path": file_path,
+        "full_path": full_path,
+    }
+
+
+@frappe.whitelist()
+def ide_push(request_name: str, push_branch: int = 1, create_pr: int = 1):
+    """Commit current changes, push branch, and optionally create PR from the IDE."""
+    if not request_name:
+        frappe.throw(_("Request name is required."))
+
+    doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    if not (doc.branch_name or "").strip():
+        frappe.throw(_("No branch on this request."))
+
+    busy = ("Understanding", "Planning", "Implementing", "Reviewing", "Building", "Pushing")
+    if doc.status in busy:
+        frappe.throw(_("Agent is busy (status: {0}).").format(doc.status))
+
+    push_branch = int(push_branch or 0)
+    create_pr = int(create_pr or 0)
+    if not push_branch and not create_pr:
+        frappe.throw(_("Select at least one action (push branch or create PR)."))
+
+    frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Pushing")
+    frappe.db.commit()
+
+    frappe.enqueue(
+        "ampower_koda.agent.executor.run_deploy_phase",
+        queue="default",
+        timeout=600,
+        request_name=request_name,
+        do_push=bool(push_branch),
+        do_pr=bool(create_pr),
+    )
+
+    if push_branch and create_pr:
+        msg = _("Committing, pushing, and creating PR...")
+    elif push_branch:
+        msg = _("Committing and pushing branch {0}...").format(doc.branch_name)
+    else:
+        msg = _("Committing and creating PR...")
+    return {"status": "ok", "message": msg}
 
 
 @frappe.whitelist()

--- a/ampower_koda/agent/api.py
+++ b/ampower_koda/agent/api.py
@@ -10,7 +10,7 @@ import frappe
 from frappe import _
 
 from ampower_koda.agent.errors import log_agent_error
-from ampower_koda.agent.executor import _generate_patch_diff, as_json_list
+from ampower_koda.agent.executor import _generate_patch_diff
 from ampower_koda.agent.git_ops import (
     branch_exists,
     checkout_base,
@@ -90,6 +90,9 @@ def start_agent(request_name: str):
         "conversation_log": "",
         "understanding_snapshot": "",
         "change_summary": "",
+        "follow_up_message": "",
+        "follow_up_count": 0,
+        "implementation_snapshot": "",
         # files_changed is a JSON column with a json_valid() CHECK constraint —
         # "" is not valid JSON, so clear it with NULL (allowed) instead.
         "files_changed": None,
@@ -125,59 +128,15 @@ def submit_follow_up(request_name: str, follow_up_message: str):
 
     _validate_provider_key(doc)
 
-    base_request = (doc.user_message or "").strip()
     follow_up = (follow_up_message or "").strip()
+    follow_up_count = int(doc.follow_up_count or 0) + 1
 
-    context_lines = []
-    if doc.status:
-        context_lines.append(f"- Previous status: {doc.status}")
-    if doc.branch_name:
-        context_lines.append(f"- Previous branch: {doc.branch_name}")
-    if doc.pr_url:
-        context_lines.append(f"- Previous PR: {doc.pr_url}")
-    if doc.error_log:
-        context_lines.append(f"- Previous error snapshot: {(doc.error_log or '')[:400]}")
-    context_text = "\n".join(context_lines) if context_lines else "- No additional run metadata recorded."
-
-    changed_paths = []
-    try:
-        for row in as_json_list(doc.files_changed):
-            p = (row or {}).get("path") if isinstance(row, dict) else None
-            if p:
-                changed_paths.append(p)
-    except Exception:
-        log_agent_error(
-            "Agent API: submit_follow_up files_changed",
-            f"request={request_name}\n{frappe.get_traceback()}",
-        )
-    changed_hint = "\n".join(f"- {p}" for p in changed_paths[:20]) if changed_paths else "- (not recorded)"
-
-    merged_message = (
-        f"{base_request}\n\n"
-        "## FOLLOW-UP ISSUE AFTER USER TESTING\n"
-        f"{follow_up}\n\n"
-        "## CONTEXT FROM PREVIOUS RUN\n"
-        f"{context_text}\n\n"
-        "### Instructions for follow-up\n"
-        "- Fix the follow-up issue precisely.\n"
-        "- Keep all previously working functionality intact.\n"
-        "- Prefer surgical changes over broad rewrites.\n"
-    )
-    focused_plan = (
-        "Follow-up fix plan (same branch, no re-explore):\n"
-        "1) Reproduce the exact follow-up issue from USER REQUEST.\n"
-        "2) Inspect only the files directly related to the issue first.\n"
-        "3) Apply minimal targeted edits.\n"
-        "4) Run validate_code on changed .py/.js and verify no regressions in touched flows.\n"
-        "5) Report precise files changed and why.\n\n"
-        "Likely affected files from previous run:\n"
-        f"{changed_hint}"
-    )
-
+    # Preserve the approved plan and original user_message. Follow-up context is
+    # stored separately and passed into the execution graph as a patch-only run.
     frappe.db.set_value(DOCTYPE_NAME, request_name, {
         "status": "Implementing",
-        "user_message": merged_message[:50000],
-        "agent_plan": focused_plan[:50000],
+        "follow_up_message": follow_up[:50000],
+        "follow_up_count": follow_up_count,
         "error_log": "",
         "bench_log": "",
         "patch_diff": "",
@@ -190,8 +149,9 @@ def submit_follow_up(request_name: str, follow_up_message: str):
         timeout=1800,
         request_name=request_name,
         preserve_branch=1,
+        is_follow_up=1,
     )
-    return {"status": "ok", "message": _("Follow-up run started on existing branch (explore/plan skipped).")}
+    return {"status": "ok", "message": _("Follow-up patch started on existing branch (plan preserved).")}
 
 
 @frappe.whitelist()

--- a/ampower_koda/agent/api.py
+++ b/ampower_koda/agent/api.py
@@ -10,7 +10,7 @@ import frappe
 from frappe import _
 
 from ampower_koda.agent.errors import log_agent_error
-from ampower_koda.agent.executor import _generate_patch_diff
+from ampower_koda.agent.executor import _generate_patch_diff, as_json_list
 from ampower_koda.agent.git_ops import (
     branch_exists,
     checkout_base,
@@ -21,6 +21,7 @@ from ampower_koda.agent.git_ops import (
     run_git,
 )
 from ampower_koda.agent.graph import _get_bench_env
+from ampower_koda.agent.prompts import plan_has_open_questions
 
 DOCTYPE_NAME = "Agent Request"
 
@@ -88,6 +89,7 @@ def start_agent(request_name: str):
         "bench_log": "",
         "patch_diff": "",
         "conversation_log": "",
+        "understanding_snapshot": "",
     })
     frappe.db.commit()
 
@@ -136,8 +138,8 @@ def submit_follow_up(request_name: str, follow_up_message: str):
 
     changed_paths = []
     try:
-        for row in json.loads(doc.files_changed or "[]"):
-            p = (row or {}).get("path")
+        for row in as_json_list(doc.files_changed):
+            p = (row or {}).get("path") if isinstance(row, dict) else None
             if p:
                 changed_paths.append(p)
     except Exception:
@@ -203,6 +205,12 @@ def execute_existing_plan(request_name: str):
     if not (doc.agent_plan or "").strip():
         frappe.throw(_("No plan found for this request."))
 
+    if plan_has_open_questions(doc.agent_plan or ""):
+        frappe.throw(_(
+            "This plan has open questions in 'Questions for User'. "
+            "Resolve them before executing."
+        ))
+
     # Implementation can only start if we are at the approval stage or have finished a previous run.
     allowed = ("Awaiting Approval", "Failed", "Cancelled", "Completed", "Awaiting Push Approval")
     if doc.status not in allowed:
@@ -240,6 +248,17 @@ def approve_plan(request_name: str, edited_plan: str = None):
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
     if doc.status != "Awaiting Approval":
         frappe.throw(_("Cannot approve plan. Agent status is {0}.").format(doc.status))
+
+    plan_to_run = (edited_plan or doc.agent_plan or "").strip()
+    if not plan_to_run:
+        frappe.throw(_("No plan found for this request."))
+
+    if plan_has_open_questions(plan_to_run):
+        frappe.throw(_(
+            "This plan has open questions in 'Questions for User'. "
+            "Answer them in the request description, edit the plan to resolve them, "
+            "or replace that section with 'None — request is fully clear.' before approving."
+        ))
 
     if edited_plan is not None and edited_plan.strip():
         frappe.db.set_value(DOCTYPE_NAME, request_name, "agent_plan", edited_plan.strip()[:50000])
@@ -674,6 +693,8 @@ def get_change_tree(request_name: str):
     changed, source = _get_changed_files_for_request(doc)
     tree = _build_directory_tree(repo_root, changed)
 
+    branch_state = _get_branch_state(doc)
+
     pending_cmds = []
     try:
         pending_cmds = json.loads(doc.pending_bench_commands or "[]")
@@ -688,6 +709,8 @@ def get_change_tree(request_name: str):
         "app_name": app_name,
         "base_branch": (doc.base_branch or "main").strip(),
         "branch_name": (doc.branch_name or "").strip(),
+        "current_branch": branch_state["current_branch"],
+        "branch_matches": branch_state["matches"],
         "source": source,
         "changed": changed,
         "tree": tree,
@@ -752,24 +775,58 @@ def _detect_editor_language(file_path: str) -> str:
     }.get(ext, "Text")
 
 
-def _ensure_agent_branch(doc) -> str:
-    """Checkout the request's agent branch before IDE file writes."""
+def _get_branch_state(doc) -> dict:
+    """Return the repo's current branch and whether it matches the request branch.
+
+    This never checks out a branch. `matches` is True only when the request has a
+    branch and the repo is currently on it.
+    """
     app_name = (doc.target_app_name or "").strip()
     branch_name = (doc.branch_name or "").strip()
+    current = get_current_branch(app_name) if app_name else ""
+    matches = bool(branch_name) and current == branch_name
+    return {"current_branch": current, "branch_name": branch_name, "matches": matches}
+
+
+def _require_request_branch(doc) -> str:
+    """Ensure the repo is on the request's branch; throw on mismatch (no checkout).
+
+    Used to gate write/deploy/push actions so the IDE never silently switches the
+    branch the user has checked out.
+    """
+    app_name = (doc.target_app_name or "").strip()
     if not app_name:
         frappe.throw(_("Target app is not set on this request."))
+    branch_name = (doc.branch_name or "").strip()
     if not branch_name:
         frappe.throw(_("No agent branch found on this request."))
 
-    repo_root = get_repo_root(app_name)
-    current = get_current_branch(app_name)
-    if current != branch_name:
-        if not branch_exists(app_name, branch_name):
-            frappe.throw(_("Branch '{0}' was not found locally.").format(branch_name))
-        ok, out = run_git(["checkout", branch_name], cwd=repo_root)
-        if not ok:
-            frappe.throw(_("Could not checkout branch '{0}': {1}").format(branch_name, out))
+    state = _get_branch_state(doc)
+    if not state["matches"]:
+        frappe.throw(
+            _("Repository is on branch '{0}', not this request's branch '{1}'. "
+              "Checkout '{1}' to edit, deploy, or push.").format(
+                  state["current_branch"] or _("(unknown)"), branch_name)
+        )
     return branch_name
+
+
+def _has_pushable_changes(doc) -> bool:
+    """True if the repo has uncommitted work or committed changes vs the base branch.
+
+    Uses only local git state (working tree + base..branch); no remote fetch.
+    """
+    app_name = (doc.target_app_name or "").strip()
+    if not app_name:
+        return False
+
+    repo_root = get_repo_root(app_name)
+    ok, status_out = run_git(["status", "--short"], cwd=repo_root)
+    if ok and status_out.strip():
+        return True
+
+    changed, _source = _get_changed_files_for_request(doc)
+    return bool(changed)
 
 
 @frappe.whitelist()
@@ -782,7 +839,7 @@ def get_file_content(request_name: str, file_path: str):
         frappe.throw(_("File path is required."))
 
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
-    _ensure_agent_branch(doc)
+    _require_request_branch(doc)
     app_name = (doc.target_app_name or "").strip()
     if not app_name:
         frappe.throw(_("Target app is not set on this request."))
@@ -818,7 +875,7 @@ def save_file_content(request_name: str, file_path: str, content: str):
     if doc.status in BUSY_STATUSES:
         frappe.throw(_("Agent is busy (status: {0}).").format(doc.status))
 
-    _ensure_agent_branch(doc)
+    _require_request_branch(doc)
     app_name = (doc.target_app_name or "").strip()
 
     repo_root = get_repo_root(app_name)
@@ -850,10 +907,15 @@ def ide_push(request_name: str, push_branch: int = 1, create_pr: int = 1):
     if doc.status in BUSY_STATUSES:
         frappe.throw(_("Agent is busy (status: {0}).").format(doc.status))
 
+    _require_request_branch(doc)
+
     push_branch = int(push_branch or 0)
     create_pr = int(create_pr or 0)
     if not push_branch and not create_pr:
         frappe.throw(_("Select at least one action (push branch or create PR)."))
+
+    if not _has_pushable_changes(doc):
+        return {"status": "noop", "message": _("No changes to push.")}
 
     frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Pushing")
     frappe.db.commit()

--- a/ampower_koda/agent/api.py
+++ b/ampower_koda/agent/api.py
@@ -4,11 +4,12 @@
 import json
 import os
 import subprocess
+from functools import wraps
 
 import frappe
 from frappe import _
 
-from ampower_koda.agent import tools as agent_tools
+from ampower_koda.agent.errors import log_agent_error
 from ampower_koda.agent.executor import _generate_patch_diff
 from ampower_koda.agent.git_ops import (
     branch_exists,
@@ -23,12 +24,35 @@ from ampower_koda.agent.graph import _get_bench_env
 
 DOCTYPE_NAME = "Agent Request"
 
+# Statuses from which a new run or follow-up may be started (agent is idle or finished).
+RESTARTABLE_STATUSES = (
+    "Queued", "Failed", "Cancelled", "Completed",
+    "Awaiting Approval", "Awaiting Push Approval",
+)
+
+# Statuses where the agent is actively working, so manual actions must wait.
+BUSY_STATUSES = (
+    "Understanding", "Planning", "Implementing",
+    "Reviewing", "Building", "Pushing",
+)
+
+
+def _whitelist_logged(fn):
+    """Log unexpected API failures to Frappe Error Log before re-raising."""
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except (frappe.ValidationError, frappe.PermissionError, frappe.DoesNotExistError):
+            raise
+        except Exception:
+            log_agent_error(f"Agent API: {fn.__name__}")
+            raise
+    return wrapper
+
 
 def _validate_provider_key(doc):
-    """
-    Verifies that the AI provider and its API key are correctly configured in settings.
-    This check ensures the agent has its 'brain' ready before it attempts any work.
-    """
+    """Ensure the AI provider is enabled and its API key is configured in settings."""
     settings = frappe.get_single("Agent Settings")
     if not settings.enable_ai_agent:
         frappe.throw(_("AI Coding Agent is disabled in Agent Settings."))
@@ -44,21 +68,14 @@ def _validate_provider_key(doc):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def start_agent(request_name: str):
-    """
-    Initiates the full workflow from scratch. 
-    This guides the agent through exploring the codebase and drafting a detailed plan 
-    for your review before any implementation begins.
-    """
+    """Start a full run from scratch: explore the codebase, then draft a plan for approval."""
     if not request_name:
         frappe.throw(_("Request name is required."))
 
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
-    
-    # We only allow starting the agent if it is currently idle or in a terminal state.
-    # This prevents accidental overlapping runs on the same request.
-    restartable = ("Queued", "Failed", "Cancelled", "Completed", "Awaiting Approval", "Awaiting Push Approval")
-    if doc.status not in restartable:
+    if doc.status not in RESTARTABLE_STATUSES:
         frappe.throw(_("Agent is already busy (status: {0}).").format(doc.status))
 
     _validate_provider_key(doc)
@@ -84,6 +101,7 @@ def start_agent(request_name: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def submit_follow_up(request_name: str, follow_up_message: str):
     """
     Append a user follow-up issue to existing context and run a surgical fix
@@ -95,8 +113,7 @@ def submit_follow_up(request_name: str, follow_up_message: str):
         frappe.throw(_("Follow-up message is required."))
 
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
-    restartable = ("Queued", "Failed", "Cancelled", "Completed", "Awaiting Approval", "Awaiting Push Approval")
-    if doc.status not in restartable:
+    if doc.status not in RESTARTABLE_STATUSES:
         frappe.throw(_("Follow-up is allowed only when the agent is idle (status: {0}).").format(doc.status))
     if not (doc.branch_name or "").strip():
         frappe.throw(_("Follow-up fix needs an existing branch on this request."))
@@ -124,7 +141,10 @@ def submit_follow_up(request_name: str, follow_up_message: str):
             if p:
                 changed_paths.append(p)
     except Exception:
-        pass
+        log_agent_error(
+            "Agent API: submit_follow_up files_changed",
+            f"request={request_name}\n{frappe.get_traceback()}",
+        )
     changed_hint = "\n".join(f"- {p}" for p in changed_paths[:20]) if changed_paths else "- (not recorded)"
 
     merged_message = (
@@ -170,6 +190,7 @@ def submit_follow_up(request_name: str, follow_up_message: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def execute_existing_plan(request_name: str):
     """
     Skips the exploration and planning phases to go straight to implementation.
@@ -207,6 +228,7 @@ def execute_existing_plan(request_name: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def approve_plan(request_name: str, edited_plan: str = None):
     """
     Confirms the plan and begins the implementation phase.
@@ -238,6 +260,7 @@ def approve_plan(request_name: str, edited_plan: str = None):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def reject_plan(request_name: str):
     """Reject the plan and set status to Cancelled."""
     if not request_name:
@@ -260,6 +283,7 @@ def reject_plan(request_name: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def approve_bench(request_name: str, commands: str = None):
     """Approves and runs the pending bench commands (migrate, build, clear-cache, etc.).
     Optionally pass an edited list of commands as a JSON array to override the defaults."""
@@ -271,14 +295,15 @@ def approve_bench(request_name: str, commands: str = None):
         frappe.throw(_("Cannot approve bench. Agent status is {0}.").format(doc.status))
 
     if commands:
-
         try:
             cmd_list = json.loads(commands)
-            if isinstance(cmd_list, list) and cmd_list:
-                frappe.db.set_value(DOCTYPE_NAME, request_name,
-                    "pending_bench_commands", json.dumps(cmd_list))
         except (ValueError, TypeError):
-            pass
+            frappe.throw(_("Invalid commands format."))
+        if isinstance(cmd_list, list) and cmd_list:
+            frappe.db.set_value(
+                DOCTYPE_NAME, request_name,
+                "pending_bench_commands", json.dumps(cmd_list),
+            )
 
     frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Building")
     frappe.db.commit()
@@ -292,12 +317,11 @@ def approve_bench(request_name: str, commands: str = None):
 
     cmds = []
     try:
-        
         cmds = json.loads(
             frappe.db.get_value(DOCTYPE_NAME, request_name, "pending_bench_commands") or "[]"
         )
-    except Exception:
-        pass
+    except (ValueError, TypeError):
+        cmds = []
 
     return {
         "status": "ok",
@@ -306,6 +330,7 @@ def approve_bench(request_name: str, commands: str = None):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def approve_push(request_name: str, push_branch: int = 1, create_pr: int = 1):
     """Approves pushing the feature branch to remote and/or opening a pull request.
     Set push_branch=1 to push, create_pr=1 to create a PR. At least one must be selected."""
@@ -343,6 +368,7 @@ def approve_push(request_name: str, push_branch: int = 1, create_pr: int = 1):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def checkout_base_branch(request_name: str):
     """Manually checkout the base branch for the target app."""
     if not request_name:
@@ -369,6 +395,7 @@ def checkout_base_branch(request_name: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def get_default_bench_commands(request_name: str):
     """Returns the default list of bench commands for the request's target app:
     migrate, build, clear-cache, and supervisorctl restart."""
@@ -391,12 +418,16 @@ def get_default_bench_commands(request_name: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def run_selected_bench_commands(request_name: str, commands: str = None):
     """Run user-selected bench commands. commands is a JSON array of command strings."""
     if not request_name:
         frappe.throw(_("Request name is required."))
 
-    
+    doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    if doc.status in BUSY_STATUSES:
+        frappe.throw(_("Agent is busy (status: {0}).").format(doc.status))
+
     cmds = []
     if commands:
         try:
@@ -429,8 +460,16 @@ def run_selected_bench_commands(request_name: str, commands: str = None):
             output_parts.append(f"$ {cmd}\n{status_str}\n{out.strip()}\n")
         except subprocess.TimeoutExpired:
             output_parts.append(f"$ {cmd}\nTIMEOUT after 900s\n")
+            log_agent_error(
+                "Agent API: run_selected_bench_commands timeout",
+                f"request={request_name}\ncmd={cmd}",
+            )
         except Exception as e:
             output_parts.append(f"$ {cmd}\nERROR: {e}\n")
+            log_agent_error(
+                "Agent API: run_selected_bench_commands",
+                f"request={request_name}\ncmd={cmd}\n{e}\n{frappe.get_traceback()}",
+            )
 
     bench_log = "\n".join(output_parts)
     frappe.db.set_value(DOCTYPE_NAME, request_name, "bench_log", bench_log[:50000])
@@ -440,6 +479,7 @@ def run_selected_bench_commands(request_name: str, commands: str = None):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def get_agent_status(request_name: str):
     """Return current status and key fields for a request."""
     if not request_name:
@@ -619,6 +659,7 @@ def _get_changed_files_for_request(doc) -> tuple[dict[str, str], str]:
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def get_change_tree(request_name: str):
     """Return full app directory tree with agent-modified files highlighted."""
     if not request_name:
@@ -637,7 +678,10 @@ def get_change_tree(request_name: str):
     try:
         pending_cmds = json.loads(doc.pending_bench_commands or "[]")
     except Exception:
-        pass
+        log_agent_error(
+            "Agent API: get_change_tree pending_bench_commands",
+            f"request={request_name}\n{frappe.get_traceback()}",
+        )
 
     return {
         "request_name": doc.name,
@@ -658,6 +702,7 @@ def get_change_tree(request_name: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def get_file_diff(request_name: str, file_path: str):
     """Return untruncated unified diff for one file in the agent's changes."""
     if not request_name:
@@ -728,6 +773,7 @@ def _ensure_agent_branch(doc) -> str:
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def get_file_content(request_name: str, file_path: str):
     """Return full file content for the IDE editor."""
     if not request_name:
@@ -758,6 +804,7 @@ def get_file_content(request_name: str, file_path: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def save_file_content(request_name: str, file_path: str, content: str):
     """Save edited file content from the IDE to the agent branch working tree."""
     if not request_name:
@@ -768,6 +815,9 @@ def save_file_content(request_name: str, file_path: str, content: str):
         frappe.throw(_("File content is required."))
 
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
+    if doc.status in BUSY_STATUSES:
+        frappe.throw(_("Agent is busy (status: {0}).").format(doc.status))
+
     _ensure_agent_branch(doc)
     app_name = (doc.target_app_name or "").strip()
 
@@ -787,6 +837,7 @@ def save_file_content(request_name: str, file_path: str, content: str):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def ide_push(request_name: str, push_branch: int = 1, create_pr: int = 1):
     """Commit current changes, push branch, and optionally create PR from the IDE."""
     if not request_name:
@@ -796,8 +847,7 @@ def ide_push(request_name: str, push_branch: int = 1, create_pr: int = 1):
     if not (doc.branch_name or "").strip():
         frappe.throw(_("No branch on this request."))
 
-    busy = ("Understanding", "Planning", "Implementing", "Reviewing", "Building", "Pushing")
-    if doc.status in busy:
+    if doc.status in BUSY_STATUSES:
         frappe.throw(_("Agent is busy (status: {0}).").format(doc.status))
 
     push_branch = int(push_branch or 0)
@@ -827,12 +877,16 @@ def ide_push(request_name: str, push_branch: int = 1, create_pr: int = 1):
 
 
 @frappe.whitelist()
+@_whitelist_logged
 def cancel_agent_request(request_name: str):
     """Cancel a queued or running request (best-effort)."""
+    if not request_name:
+        frappe.throw(_("Request name is required."))
+
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
     if doc.status in ("Completed", "Failed", "Cancelled"):
-        frappe.msgprint(_("Request already finished."))
-        return
+        return {"status": "noop", "message": _("Request already finished.")}
+
     frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Cancelled")
     frappe.db.commit()
-    return True
+    return {"status": "ok", "message": _("Request cancelled.")}

--- a/ampower_koda/agent/errors.py
+++ b/ampower_koda/agent/errors.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
+
+import frappe
+
+
+def log_agent_error(title: str, message: str | None = None) -> None:
+    """Write an entry to Frappe Error Log. Never raises."""
+    try:
+        frappe.log_error(message or frappe.get_traceback(), title)
+    except Exception:
+        pass

--- a/ampower_koda/agent/executor.py
+++ b/ampower_koda/agent/executor.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-# Two-phase executor: planning phase (understand+plan) and execution phase (implement+review+bench+deploy)
+# Executor phases: planning (understand + plan), execution (implement + review),
+# bench + commit, and deploy (push + PR). Enqueued as background jobs from api.py.
 
+import datetime
 import json
 import os
+import subprocess
 
 import frappe
-import subprocess
+from ampower_koda.agent.errors import log_agent_error
 from ampower_koda.agent.graph import (
     _get_bench_env,
     _message_content_to_str,
@@ -87,7 +90,10 @@ def _revert_previous_changes(app_name: str, base_branch: str, request_name: str 
                 "message": summary,
             }, user=user or "Administrator")
         except Exception:
-            pass
+            log_agent_error(
+                "Agent Executor: revert publish",
+                f"request={request_name}\n{frappe.get_traceback()}",
+            )
         return summary
 
     return ""
@@ -132,11 +138,7 @@ def _get_doc_config(request_name: str) -> dict:
 
 
 def _update_status(request_name: str, user: str, status: str, message: str = "", **kwargs):
-    """
-    Updates the request's status and persists key fields to the database.
-    This function also broadcasts the progress via realtime events, acting as the
-    primary 'voice' of the agent for the end-user.
-    """
+    """Persist the status (plus any allowed fields) and broadcast progress via realtime."""
     frappe.db.set_value(DOCTYPE_NAME, request_name, "status", status)
     allowed_fields = [
         "branch_name", "pr_url", "pr_number", "conversation_log",
@@ -158,16 +160,12 @@ def _update_status(request_name: str, user: str, status: str, message: str = "",
 # ---------------------------------------------------------------------------
 
 def run_planning_phase(request_name: str) -> None:
-    """
-    Executes the initial discovery phase of the agent's work.
-    This phase involves building a mental model of the codebase (Understanding)
-    and drafting a proposed path forward (Planning).
-    """
+    """Run the planning phase (understand + plan) and pause for plan approval."""
     frappe.set_user("Administrator")
     try:
         config = _get_doc_config(request_name)
     except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "Agent Planning Config Error")
+        log_agent_error("Agent Planning Config Error", frappe.get_traceback())
         frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Failed")
         frappe.db.set_value(DOCTYPE_NAME, request_name, "error_log", str(e))
         frappe.db.commit()
@@ -187,8 +185,6 @@ def run_planning_phase(request_name: str) -> None:
 
         _update_status(request_name, user, "Understanding", "Exploring codebase...")
 
-        # We build the planning graph which defines the agent's thought process
-        # for discovering relevant files and drafting the solution.
         graph = build_planning_graph()
         initial = {
             "user_message": doc.user_message or "",
@@ -228,7 +224,7 @@ def run_planning_phase(request_name: str) -> None:
 
     except Exception as e:
         tb = frappe.get_traceback()
-        frappe.log_error(tb, "Agent Planning Error")
+        log_agent_error("Agent Planning Error", tb)
         _update_status(request_name, user, "Failed", str(e), error_log=tb)
 
 
@@ -237,16 +233,16 @@ def run_planning_phase(request_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
-    """
-    Carries out the implementation of the approved plan.
-    This phase creates a working branch, applies code changes, and performs
-    an automated review to ensure quality and correctness.
+    """Create/reuse the working branch, run implement + review, then await bench approval.
+
+    When preserve_branch is set, reuse the request's existing branch for a follow-up
+    fix instead of creating a fresh one.
     """
     frappe.set_user("Administrator")
     try:
         config = _get_doc_config(request_name)
     except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "Agent Execution Config Error")
+        log_agent_error("Agent Execution Config Error", frappe.get_traceback())
         frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Failed")
         frappe.db.set_value(DOCTYPE_NAME, request_name, "error_log", str(e))
         frappe.db.commit()
@@ -309,8 +305,7 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
 
         plan = doc.agent_plan or ""
 
-        # We parse the existing log to ensure the execution graph has full context
-        # of what was discovered during the planning phase.
+        # Carry the planning-phase stage log into execution for continuity.
         prev_stage_log = _parse_stage_log(doc.stage_log or "")
 
         graph = build_execution_graph()
@@ -370,7 +365,7 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
 
     except Exception as e:
         tb = frappe.get_traceback()
-        frappe.log_error(tb, "Agent Execution Error")
+        log_agent_error("Agent Execution Error", tb)
         _update_status(request_name, user, "Failed", str(e), error_log=tb)
 
 
@@ -410,7 +405,6 @@ def _compute_bench_commands(app_name: str, edits: list) -> list[str]:
 
 def _publish_bench_log(user, request_name, cmd, success, output_preview=""):
     """Broadcast a bench command start/result event via Frappe realtime."""
-    import datetime
     ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     frappe.publish_realtime("agent_log", {
         "request_name": request_name,
@@ -428,15 +422,12 @@ def _publish_bench_log(user, request_name, cmd, success, output_preview=""):
 
 
 def run_bench_and_commit(request_name: str) -> None:
-    """
-    Executes the approved bench commands (migrate, build, clear-cache, etc.) and then
-waits for the user to review the live changes before approving the final commit and push.
-    """
+    """Run the approved bench commands, then pause for push approval so the user can test."""
     frappe.set_user("Administrator")
     try:
         config = _get_doc_config(request_name)
     except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "Agent Bench Config Error")
+        log_agent_error("Agent Bench Config Error", frappe.get_traceback())
         frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Failed")
         frappe.db.set_value(DOCTYPE_NAME, request_name, "error_log", str(e))
         frappe.db.commit()
@@ -492,9 +483,17 @@ waits for the user to review the live changes before approving the final commit 
             except subprocess.TimeoutExpired:
                 bench_output_parts.append(f"$ {cmd}\nTIMEOUT after 900s\n")
                 _publish_bench_log(user, request_name, cmd, False, "TIMEOUT after 900s")
+                log_agent_error(
+                    "Agent Executor: bench command timeout",
+                    f"request={request_name}\ncmd={cmd}",
+                )
             except Exception as e:
                 bench_output_parts.append(f"$ {cmd}\nERROR: {e}\n")
                 _publish_bench_log(user, request_name, cmd, False, str(e))
+                log_agent_error(
+                    "Agent Executor: bench command",
+                    f"request={request_name}\ncmd={cmd}\n{e}\n{frappe.get_traceback()}",
+                )
 
         if deferred_cmds:
             for cmd in deferred_cmds:
@@ -519,12 +518,15 @@ waits for the user to review the live changes before approving the final commit 
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                log_agent_error(
+                    "Agent Executor: deferred supervisorctl",
+                    f"request={request_name}\ncmd={cmd}\n{e}\n{frappe.get_traceback()}",
+                )
 
     except Exception as e:
         tb = frappe.get_traceback()
-        frappe.log_error(tb, "Agent Bench+Commit Error")
+        log_agent_error("Agent Bench+Commit Error", tb)
         _update_status(request_name, user, "Failed", str(e), error_log=tb)
 
 
@@ -533,15 +535,12 @@ waits for the user to review the live changes before approving the final commit 
 # ---------------------------------------------------------------------------
 
 def run_deploy_phase(request_name: str, do_push: bool = True, do_pr: bool = True) -> None:
-    """
-    Finalizes the task by committing the changes and pushing them to GitHub.
-    Depending on the user's choice, it can also automatically create a Pull Request.
-    """
+    """Commit the changes, then optionally push the branch and open a pull request."""
     frappe.set_user("Administrator")
     try:
         config = _get_doc_config(request_name)
     except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "Agent Deploy Config Error")
+        log_agent_error("Agent Deploy Config Error", frappe.get_traceback())
         frappe.db.set_value(DOCTYPE_NAME, request_name, "status", "Failed")
         frappe.db.set_value(DOCTYPE_NAME, request_name, "error_log", str(e))
         frappe.db.commit()
@@ -628,7 +627,7 @@ def run_deploy_phase(request_name: str, do_push: bool = True, do_pr: bool = True
 
     except Exception as e:
         tb = frappe.get_traceback()
-        frappe.log_error(tb, "Agent Deploy Error")
+        log_agent_error("Agent Deploy Error", tb)
         _update_status(request_name, user, "Failed", str(e), error_log=tb)
 
 
@@ -661,10 +660,18 @@ def _generate_patch_diff(app_name: str) -> str:
                         content = f.read(50000)
                     parts.append(f"--- /dev/null\n+++ b/{fpath}\n" +
                                  "\n".join(f"+{line}" for line in content.split("\n")))
-                except Exception:
+                except Exception as e:
+                    log_agent_error(
+                        "Agent Executor: patch diff file read",
+                        f"app={app_name}\npath={fpath}\n{e}\n{frappe.get_traceback()}",
+                    )
                     parts.append(f"--- /dev/null\n+++ b/{fpath}\n+[binary or unreadable]")
         return "\n\n".join(parts)[:100000]
     except Exception as e:
+        log_agent_error(
+            "Agent Executor: generate patch diff",
+            f"app={app_name}\n{e}\n{frappe.get_traceback()}",
+        )
         return f"(could not generate diff: {e})"
 
 
@@ -679,13 +686,34 @@ def _save_logs(request_name: str, final_state: dict):
     else:
         stage_text = str(stage_logs)
 
-    frappe.db.set_value(DOCTYPE_NAME, request_name, {
-        "stage_log": stage_text[:50000],
-        "conversation_log": json.dumps(
-            final_state.get("intermediate_steps", []), indent=2
-        )[:50000],
-    })
-    frappe.db.commit()
+    try:
+        conversation_log = json.dumps(
+            final_state.get("intermediate_steps", []),
+            indent=2,
+            default=str,
+        )[:50000]
+    except (TypeError, ValueError) as e:
+        log_agent_error(
+            "Agent Executor: serialize conversation log",
+            f"request={request_name}\n{e}\n{frappe.get_traceback()}",
+        )
+        conversation_log = json.dumps([{
+            "phase": "Logging",
+            "output": f"Could not serialize conversation log: {e}",
+        }])[:50000]
+
+    try:
+        frappe.db.set_value(DOCTYPE_NAME, request_name, {
+            "stage_log": stage_text[:50000],
+            "conversation_log": conversation_log,
+        })
+        frappe.db.commit()
+    except Exception as e:
+        log_agent_error(
+            "Agent Executor: save logs",
+            f"request={request_name}\n{e}\n{frappe.get_traceback()}",
+        )
+        raise
 
 
 def _parse_stage_log(stage_log_text: str) -> list[dict]:
@@ -725,6 +753,9 @@ def _extract_understanding(doc) -> str:
         for step in steps:
             if step.get("phase") == "Understanding":
                 return _message_content_to_str(step.get("output", ""))
-    except (json.JSONDecodeError, TypeError):
-        pass
+    except (json.JSONDecodeError, TypeError) as e:
+        log_agent_error(
+            "Agent Executor: extract understanding",
+            f"request={getattr(doc, 'name', '')}\n{e}\n{frappe.get_traceback()}",
+        )
     return ""

--- a/ampower_koda/agent/executor.py
+++ b/ampower_koda/agent/executor.py
@@ -6,12 +6,14 @@ import os
 
 import frappe
 import subprocess
-from ampower_koda.agent.graph import _get_bench_env
 from ampower_koda.agent.graph import (
+    _get_bench_env,
+    _message_content_to_str,
     build_planning_graph,
     build_execution_graph,
 )
 from ampower_koda.agent.git_ops import (
+    branch_exists,
     generate_branch_name,
     get_repo_root,
     get_current_branch,
@@ -22,7 +24,7 @@ from ampower_koda.agent.git_ops import (
     create_pull_request,
 )
 
-DOCTYPE_NAME = "AI Agent Request"
+DOCTYPE_NAME = "Agent Request"
 
 
 def _revert_previous_changes(app_name: str, base_branch: str, request_name: str = "",
@@ -92,9 +94,9 @@ def _revert_previous_changes(app_name: str, base_branch: str, request_name: str 
 
 
 def _get_doc_config(request_name: str) -> dict:
-    """Load the AI Agent Request document and return config needed for the graph state."""
+    """Load the Agent Request document and return config needed for the graph state."""
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
-    settings = frappe.get_single("AI Agent Settings")
+    settings = frappe.get_single("Agent Settings")
 
     if not settings.enable_ai_agent:
         frappe.throw("AI Agent is disabled in settings")
@@ -110,7 +112,7 @@ def _get_doc_config(request_name: str) -> dict:
     field_name, env_var, label = cfg
     api_key = settings.get_password(field_name) or ""
     if not api_key.strip():
-        frappe.throw(f"{label} not set in AI Agent Settings")
+        frappe.throw(f"{label} not set in Agent Settings")
     os.environ[env_var] = api_key.strip()
 
     return {
@@ -234,7 +236,7 @@ def run_planning_phase(request_name: str) -> None:
 # Phase 2: Execution (Implement + Review)
 # ---------------------------------------------------------------------------
 
-def run_execution_phase(request_name: str) -> None:
+def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
     """
     Carries out the implementation of the approved plan.
     This phase creates a working branch, applies code changes, and performs
@@ -254,25 +256,56 @@ def run_execution_phase(request_name: str) -> None:
     doc = frappe.get_doc(DOCTYPE_NAME, request_name)
 
     try:
-        revert_msg = _revert_previous_changes(
-            config["target_app_name"], config["base_branch"],
-            request_name=request_name, user=user,
-            branch_prefix=config["branch_prefix"],
-        )
-        if revert_msg:
-            _update_status(request_name, user, "Implementing", f"Cleaned up: {revert_msg}")
-
         app_name = config["target_app_name"]
-        branch_name = generate_branch_name(request_name, config["branch_prefix"], app_name)
-        ok, msg = create_branch(app_name, branch_name, config["base_branch"])
-        if not ok:
-            _update_status(request_name, user, "Failed",
-                f"Failed to create working branch: {msg}",
-                error_log=f"create_branch failed: {msg}")
-            return
-        _update_status(request_name, user, "Implementing",
-            f"Created branch '{branch_name}'. Starting implementation...",
-            branch_name=branch_name)
+        keep_same_branch = bool(int(preserve_branch or 0))
+
+        if keep_same_branch:
+            branch_name = (doc.branch_name or "").strip()
+            if not branch_name:
+                _update_status(request_name, user, "Failed",
+                    "Follow-up mode requires an existing branch on this request.",
+                    error_log="Missing branch_name for follow-up execution.")
+                return
+            if not branch_exists(app_name, branch_name):
+                _update_status(request_name, user, "Failed",
+                    f"Follow-up branch '{branch_name}' was not found in local repo.",
+                    error_log=f"Branch not found: {branch_name}")
+                return
+
+            repo_root = get_repo_root(app_name)
+            current = get_current_branch(app_name)
+            if current != branch_name:
+                ok, msg = run_git(["checkout", branch_name], cwd=repo_root)
+                if not ok:
+                    _update_status(request_name, user, "Failed",
+                        f"Could not checkout follow-up branch '{branch_name}': {msg}",
+                        error_log=f"checkout failed: {msg}")
+                    return
+            # Keep same branch but start from clean HEAD for precise follow-up edits.
+            run_git(["reset", "--hard", "HEAD"], cwd=repo_root)
+            run_git(["clean", "-fd"], cwd=repo_root)
+            _update_status(request_name, user, "Implementing",
+                f"Follow-up mode: using existing branch '{branch_name}' (explore/plan skipped).",
+                branch_name=branch_name)
+        else:
+            revert_msg = _revert_previous_changes(
+                config["target_app_name"], config["base_branch"],
+                request_name=request_name, user=user,
+                branch_prefix=config["branch_prefix"],
+            )
+            if revert_msg:
+                _update_status(request_name, user, "Implementing", f"Cleaned up: {revert_msg}")
+
+            branch_name = generate_branch_name(request_name, config["branch_prefix"], app_name)
+            ok, msg = create_branch(app_name, branch_name, config["base_branch"])
+            if not ok:
+                _update_status(request_name, user, "Failed",
+                    f"Failed to create working branch: {msg}",
+                    error_log=f"create_branch failed: {msg}")
+                return
+            _update_status(request_name, user, "Implementing",
+                f"Created branch '{branch_name}'. Starting implementation...",
+                branch_name=branch_name)
 
         plan = doc.agent_plan or ""
 
@@ -691,7 +724,7 @@ def _extract_understanding(doc) -> str:
         steps = json.loads(doc.conversation_log or "[]")
         for step in steps:
             if step.get("phase") == "Understanding":
-                return step.get("output", "")
+                return _message_content_to_str(step.get("output", ""))
     except (json.JSONDecodeError, TypeError):
         pass
     return ""

--- a/ampower_koda/agent/executor.py
+++ b/ampower_koda/agent/executor.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-# Executor phases: planning (understand + plan), execution (implement + review),
+# Executor phases: planning (understand + plan), execution (implement),
 # bench + commit, and deploy (push + PR). Enqueued as background jobs from api.py.
 
 import datetime
 import json
 import os
+import re
 import subprocess
 
 import frappe
@@ -15,7 +16,6 @@ from ampower_koda.agent.graph import (
     build_planning_graph,
     build_execution_graph,
 )
-from ampower_koda.agent.prompts import plan_has_open_questions
 from ampower_koda.agent.git_ops import (
     branch_exists,
     generate_branch_name,
@@ -145,7 +145,7 @@ def _update_status(request_name: str, user: str, status: str, message: str = "",
         "branch_name", "pr_url", "pr_number", "conversation_log",
         "agent_plan", "files_changed", "error_log", "tokens_used",
         "cost_estimate", "stage_log", "bench_log", "patch_diff",
-        "pending_bench_commands",
+        "pending_bench_commands", "change_summary",
     ]
     if kwargs:
         for k, v in kwargs.items():
@@ -224,13 +224,7 @@ def run_planning_phase(request_name: str) -> None:
         })
         frappe.db.commit()
 
-        if plan_has_open_questions(plan):
-            approval_msg = (
-                "Plan generated with open questions. Review 'Questions for User', "
-                "update the request or edit the plan, then approve."
-            )
-        else:
-            approval_msg = "Plan generated. Review the todos and approve to start implementation."
+        approval_msg = "Plan generated. Review the todos and approve to start implementation."
 
         _update_status(request_name, user, "Awaiting Approval", approval_msg,
             tokens_used=int(final_state.get("tokens_used") or 0))
@@ -242,11 +236,11 @@ def run_planning_phase(request_name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Phase 2: Execution (Implement + Review)
+# Phase 2: Execution (Implement)
 # ---------------------------------------------------------------------------
 
 def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
-    """Create/reuse the working branch, run implement + review, then await bench approval.
+    """Create/reuse the working branch, run the implement pass, then await bench approval.
 
     When preserve_branch is set, reuse the request's existing branch for a follow-up
     fix instead of creating a fresh one.
@@ -355,6 +349,14 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
             return
 
         repo_root = get_repo_root(app_name)
+
+        # Drop throwaway notes/marker files the model may have created so they
+        # never reach the diff or PR.
+        stripped = _strip_agent_scratch_files(repo_root)
+        if stripped:
+            _update_status(request_name, user, "Implementing",
+                f"Removed {len(stripped)} stray file(s): {', '.join(stripped[:5])}")
+
         ok_diff, diff_out = run_git(["diff", "--stat"], cwd=repo_root)
         ok_ut, untracked = run_git(["ls-files", "--others", "--exclude-standard"], cwd=repo_root)
         has_changes = bool((diff_out or "").strip()) or bool((untracked or "").strip())
@@ -367,7 +369,13 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
 
         patch_diff = _generate_patch_diff(app_name)
 
-        edits = final_state.get("edits_made") or []
+        # Keep the recorded change set in sync with what actually remains on disk.
+        stripped_set = set(stripped)
+        edits = [
+            e for e in (final_state.get("edits_made") or [])
+            if e.get("path") not in stripped_set
+            and not (e.get("path") and _is_scratch_file(e["path"]))
+        ]
         bench_cmds = _compute_bench_commands(app_name, edits)
 
         _update_status(
@@ -375,6 +383,7 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
             f"Implementation complete. {len(bench_cmds)} bench commands need approval.",
             patch_diff=patch_diff,
             files_changed=dump_json_capped(edits),
+            change_summary=(final_state.get("change_summary") or "").strip(),
             pending_bench_commands=json.dumps(bench_cmds),
             tokens_used=int(final_state.get("tokens_used") or 0),
         )
@@ -388,6 +397,53 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
 # ---------------------------------------------------------------------------
 # Helpers: bench command computation
 # ---------------------------------------------------------------------------
+
+# Names/patterns that indicate throwaway "scratch" files the model sometimes
+# creates (progress notes, status markers, metadata dumps). These are never part
+# of a real code change and must not land in the PR.
+_SCRATCH_NAME_KEYWORDS = (
+    "note", "notes", "metadata", "summary", "readme", "changelog",
+    "finalize", "implementation_done", "done", "todo", "scratch",
+)
+
+
+def _is_scratch_file(rel_path: str) -> bool:
+    """True for agent-created doc/marker files that don't belong in the change set."""
+    name = os.path.basename(rel_path).lower()
+    _, ext = os.path.splitext(name)
+    # Loose .txt files are never a legitimate Frappe code artifact.
+    if ext == ".txt":
+        return True
+    # Markdown only when it looks like an agent note/marker (keep real code .md rare).
+    if ext == ".md" and any(k in name for k in _SCRATCH_NAME_KEYWORDS):
+        return True
+    if re.match(r"(?i)(implementation_done|finalize_|ai_feature|ai_progress)", name):
+        return True
+    return False
+
+
+def _strip_agent_scratch_files(repo_root: str) -> list[str]:
+    """Delete newly-created scratch/marker files from the working tree.
+
+    Returns the list of removed repo-relative paths. Only untracked files are
+    considered, so tracked source code is never touched.
+    """
+    ok, untracked = run_git(["ls-files", "--others", "--exclude-standard"], cwd=repo_root)
+    if not ok or not (untracked or "").strip():
+        return []
+    removed = []
+    for rel in untracked.splitlines():
+        rel = rel.strip()
+        if not rel or not _is_scratch_file(rel):
+            continue
+        try:
+            os.remove(os.path.join(repo_root, rel))
+            removed.append(rel)
+        except OSError:
+            log_agent_error("Agent Execution: strip scratch file",
+                f"could not remove {rel}\n{frappe.get_traceback()}")
+    return removed
+
 
 def _compute_bench_commands(app_name: str, edits: list) -> list[str]:
     """Determine which bench commands are needed based on which file types were edited.

--- a/ampower_koda/agent/executor.py
+++ b/ampower_koda/agent/executor.py
@@ -15,6 +15,7 @@ from ampower_koda.agent.graph import (
     build_planning_graph,
     build_execution_graph,
 )
+from ampower_koda.agent.prompts import plan_has_open_questions
 from ampower_koda.agent.git_ops import (
     branch_exists,
     generate_branch_name,
@@ -216,11 +217,23 @@ def run_planning_phase(request_name: str) -> None:
         plan = final_state.get("plan", "")
         _save_logs(request_name, final_state)
 
-        frappe.db.set_value(DOCTYPE_NAME, request_name, "agent_plan", plan[:50000])
+        understanding = _message_content_to_str(final_state.get("understanding_summary", "")).strip()
+        frappe.db.set_value(DOCTYPE_NAME, request_name, {
+            "agent_plan": plan[:50000],
+            "understanding_snapshot": understanding,
+        })
         frappe.db.commit()
 
-        _update_status(request_name, user, "Awaiting Approval",
-            "Plan generated. Please review and approve.")
+        if plan_has_open_questions(plan):
+            approval_msg = (
+                "Plan generated with open questions. Review 'Questions for User', "
+                "update the request or edit the plan, then approve."
+            )
+        else:
+            approval_msg = "Plan generated. Review the todos and approve to start implementation."
+
+        _update_status(request_name, user, "Awaiting Approval", approval_msg,
+            tokens_used=int(final_state.get("tokens_used") or 0))
 
     except Exception as e:
         tb = frappe.get_traceback()
@@ -327,6 +340,8 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
             "intermediate_steps": [],
             "edits_made": [],
             "stage_log": prev_stage_log,
+            # Continue the running token total from the planning phase.
+            "tokens_used": int(doc.tokens_used or 0),
         }
 
         final_state = graph.invoke(initial)
@@ -359,8 +374,9 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
             request_name, user, "Awaiting Bench Approval",
             f"Implementation complete. {len(bench_cmds)} bench commands need approval.",
             patch_diff=patch_diff,
-            files_changed=json.dumps(edits)[:50000],
+            files_changed=dump_json_capped(edits),
             pending_bench_commands=json.dumps(bench_cmds),
+            tokens_used=int(final_state.get("tokens_used") or 0),
         )
 
     except Exception as e:
@@ -573,10 +589,22 @@ def run_deploy_phase(request_name: str, do_push: bool = True, do_pr: bool = True
             config["git_user_name"], config["git_user_email"],
         )
         if not ok:
-            _update_status(request_name, user, "Failed",
-                f"Failed to commit changes: {msg}",
-                error_log=f"commit_changes failed: {msg}")
-            return
+            # Nothing new to commit. Only treat this as a failure if there is also
+            # nothing already committed on the branch to push. This is a safety net
+            # for races; ide_push guards the no-changes case first.
+            if "no changes to commit" in (msg or "").lower():
+                if _branch_has_commits_vs_base(app_name, config["base_branch"], branch_name):
+                    # There are existing commits worth pushing/PRing; keep going.
+                    pass
+                else:
+                    status = "Completed" if (doc.pr_url or "").strip() else "Awaiting Push Approval"
+                    _update_status(request_name, user, status, "No changes to push.")
+                    return
+            else:
+                _update_status(request_name, user, "Failed",
+                    f"Failed to commit changes: {msg}",
+                    error_log=f"commit_changes failed: {msg}")
+                return
 
         pr_url = None
         pr_number = None
@@ -635,6 +663,19 @@ def run_deploy_phase(request_name: str, do_push: bool = True, do_pr: bool = True
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _branch_has_commits_vs_base(app_name: str, base_branch: str, branch_name: str) -> bool:
+    """True if `branch_name` has commits that `base_branch` does not (local only)."""
+    if not (app_name and base_branch and branch_name):
+        return False
+    try:
+        repo_root = get_repo_root(app_name)
+        ok, out = run_git(["rev-list", "--count", f"{base_branch}..{branch_name}"], cwd=repo_root)
+        return ok and out.strip().isdigit() and int(out.strip()) > 0
+    except Exception:
+        log_agent_error("Agent Deploy: rev-list vs base", frappe.get_traceback())
+        return False
+
+
 def _generate_patch_diff(app_name: str) -> str:
     """Generate a unified diff of all uncommitted changes in the target app repo."""
     try:
@@ -676,7 +717,7 @@ def _generate_patch_diff(app_name: str) -> str:
 
 
 def _save_logs(request_name: str, final_state: dict):
-    """Persist stage_log and conversation_log to the document."""
+    """Persist stage_log and append this run's conversation_log to the document."""
     stage_logs = final_state.get("stage_log") or []
     if isinstance(stage_logs, list):
         stage_text = "\n".join(
@@ -687,20 +728,15 @@ def _save_logs(request_name: str, final_state: dict):
         stage_text = str(stage_logs)
 
     try:
-        conversation_log = json.dumps(
-            final_state.get("intermediate_steps", []),
-            indent=2,
-            default=str,
-        )[:50000]
-    except (TypeError, ValueError) as e:
+        new_block = _format_conversation_log(final_state.get("intermediate_steps", []))
+    except Exception as e:
         log_agent_error(
             "Agent Executor: serialize conversation log",
             f"request={request_name}\n{e}\n{frappe.get_traceback()}",
         )
-        conversation_log = json.dumps([{
-            "phase": "Logging",
-            "output": f"Could not serialize conversation log: {e}",
-        }])[:50000]
+        new_block = f"Could not format conversation log: {e}"
+
+    conversation_log = _append_conversation_log(request_name, new_block)
 
     try:
         frappe.db.set_value(DOCTYPE_NAME, request_name, {
@@ -746,14 +782,140 @@ def _parse_stage_log(stage_log_text: str) -> list[dict]:
     return entries
 
 
+def dump_json_capped(obj, limit: int = 50000) -> str:
+    """Serialize obj to valid JSON no longer than `limit` chars.
+
+    JSON DocType columns enforce json_valid(); naive string truncation would
+    corrupt the JSON and fail the constraint. If the full dump is too large, long
+    string values are shortened so the result stays valid JSON.
+    """
+    text = json.dumps(obj, indent=2, ensure_ascii=False, default=str)
+    if len(text) <= limit:
+        return text
+
+    def shrink(value, budget):
+        if isinstance(value, str) and len(value) > budget:
+            return value[:budget] + "…[truncated]"
+        if isinstance(value, list):
+            return [shrink(v, budget) for v in value]
+        if isinstance(value, dict):
+            return {k: shrink(v, budget) for k, v in value.items()}
+        return value
+
+    budget = 4000
+    while budget >= 200:
+        candidate = json.dumps(shrink(obj, budget), indent=2, ensure_ascii=False, default=str)
+        if len(candidate) <= limit:
+            return candidate
+        budget //= 2
+
+    return json.dumps(
+        {"_truncated": True, "note": "Log too large to store."},
+        ensure_ascii=False,
+    )
+
+
+def as_json_list(value) -> list:
+    """Coerce a JSON-typed field into a list.
+
+    Tolerates None, empty string, a JSON string, or an already-parsed list/dict —
+    JSON DocType fields may surface as either a raw string or a parsed value.
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            return []
+        if isinstance(parsed, list):
+            return parsed
+        return [parsed] if parsed else []
+    return []
+
+
+_PHASE_MARKER = "===== PHASE: "
+_RUN_MARKER = "========== RUN @ "
+# Total conversation_log kept per request across all runs. Very high on purpose:
+# each run is naturally bounded, so this only guards pathological growth.
+_CONVERSATION_LOG_LIMIT = 1_500_000
+
+
+def _format_conversation_log(steps, limit: int = 500000) -> str:
+    """Render agent steps as clean, human-readable sectioned text (no JSON escaping)."""
+    blocks = []
+    for step in steps or []:
+        if not isinstance(step, dict):
+            continue
+        phase = step.get("phase", "Step")
+        output = _message_content_to_str(step.get("output", "")).strip()
+        blocks.append(f"{_PHASE_MARKER}{phase} =====\n{output}")
+    text = "\n\n".join(blocks)
+    if len(text) > limit:
+        text = text[:limit] + "\n\n… [log truncated]"
+    return text
+
+
+def _append_conversation_log(request_name: str, new_block: str) -> str:
+    """Append this run's log block to the existing conversation_log.
+
+    The log accumulates across the request lifecycle (planning run -> execution
+    run -> follow-up runs) so the full conversation is retained. start_agent
+    clears it for a fresh from-scratch run.
+    """
+    existing = (frappe.db.get_value(DOCTYPE_NAME, request_name, "conversation_log") or "").rstrip()
+    if not (new_block or "").strip():
+        return existing
+
+    header = f"{_RUN_MARKER}{datetime.datetime.now():%Y-%m-%d %H:%M:%S} ==========\n\n"
+    block = header + new_block
+    combined = f"{existing}\n\n{block}" if existing else block
+
+    if len(combined) > _CONVERSATION_LOG_LIMIT:
+        # Keep the most recent content; drop oldest runs (understanding is also
+        # persisted separately, so extraction is unaffected by this rare trim).
+        combined = "… [older runs truncated]\n\n" + combined[-_CONVERSATION_LOG_LIMIT:]
+    return combined
+
+
 def _extract_understanding(doc) -> str:
-    """Extract understanding summary from conversation log if available."""
+    """Extract the Understanding section from the conversation log.
+
+    Prefers the dedicated understanding_snapshot field (stable across runs and log
+    trimming). Falls back to parsing the clean sectioned-text conversation log, then
+    to the legacy JSON format for requests logged before the format change.
+    """
+    snapshot = (getattr(doc, "understanding_snapshot", "") or "").strip()
+    if snapshot:
+        return snapshot
+
+    text = doc.conversation_log or ""
     try:
-        steps = json.loads(doc.conversation_log or "[]")
-        for step in steps:
-            if step.get("phase") == "Understanding":
-                return _message_content_to_str(step.get("output", ""))
-    except (json.JSONDecodeError, TypeError) as e:
+        if text.strip():
+            marker = f"{_PHASE_MARKER}Understanding ====="
+            idx = text.find(marker)
+            if idx != -1:
+                start = idx + len(marker)
+                # Stop at the next phase or run boundary, whichever comes first.
+                candidates = [
+                    pos for pos in (
+                        text.find(f"\n{_PHASE_MARKER}", start),
+                        text.find(f"\n{_RUN_MARKER}", start),
+                    ) if pos != -1
+                ]
+                next_idx = min(candidates) if candidates else -1
+                section = text[start:] if next_idx == -1 else text[start:next_idx]
+                return section.strip()
+
+            # Legacy JSON-formatted logs.
+            for step in as_json_list(text):
+                if isinstance(step, dict) and step.get("phase") == "Understanding":
+                    return _message_content_to_str(step.get("output", ""))
+    except Exception as e:
         log_agent_error(
             "Agent Executor: extract understanding",
             f"request={getattr(doc, 'name', '')}\n{e}\n{frappe.get_traceback()}",

--- a/ampower_koda/agent/executor.py
+++ b/ampower_koda/agent/executor.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-# Executor phases: planning (understand + plan), execution (implement),
+# Executor phases: planning (understand + plan), execution (implement + review),
 # bench + commit, and deploy (push + PR). Enqueued as background jobs from api.py.
 
 import datetime
+import hashlib
 import json
 import os
 import re
@@ -146,6 +147,7 @@ def _update_status(request_name: str, user: str, status: str, message: str = "",
         "agent_plan", "files_changed", "error_log", "tokens_used",
         "cost_estimate", "stage_log", "bench_log", "patch_diff",
         "pending_bench_commands", "change_summary",
+        "implementation_snapshot", "follow_up_message", "follow_up_count",
     ]
     if kwargs:
         for k, v in kwargs.items():
@@ -236,14 +238,15 @@ def run_planning_phase(request_name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Phase 2: Execution (Implement)
+# Phase 2: Execution (Implement + Review)
 # ---------------------------------------------------------------------------
 
-def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
-    """Create/reuse the working branch, run the implement pass, then await bench approval.
+def run_execution_phase(request_name: str, preserve_branch: int = 0, is_follow_up: int = 0) -> None:
+    """Create/reuse the working branch, run implement + review, then await bench approval.
 
     When preserve_branch is set, reuse the request's existing branch for a follow-up
-    fix instead of creating a fresh one.
+    patch instead of creating a fresh one. is_follow_up enables patch-only mode
+    without replacing the approved plan.
     """
     frappe.set_user("Administrator")
     try:
@@ -261,6 +264,7 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
     try:
         app_name = config["target_app_name"]
         keep_same_branch = bool(int(preserve_branch or 0))
+        is_follow_up_mode = bool(int(is_follow_up or 0)) or keep_same_branch
 
         if keep_same_branch:
             branch_name = (doc.branch_name or "").strip()
@@ -284,11 +288,10 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
                         f"Could not checkout follow-up branch '{branch_name}': {msg}",
                         error_log=f"checkout failed: {msg}")
                     return
-            # Keep same branch but start from clean HEAD for precise follow-up edits.
-            run_git(["reset", "--hard", "HEAD"], cwd=repo_root)
-            run_git(["clean", "-fd"], cwd=repo_root)
+            # Preserve existing branch state — do NOT reset/clean or we wipe the
+            # implementation the user is asking us to patch.
             _update_status(request_name, user, "Implementing",
-                f"Follow-up mode: using existing branch '{branch_name}' (explore/plan skipped).",
+                f"Follow-up patch on branch '{branch_name}' (plan preserved).",
                 branch_name=branch_name)
         else:
             revert_msg = _revert_previous_changes(
@@ -311,9 +314,18 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
                 branch_name=branch_name)
 
         plan = doc.agent_plan or ""
+        prior_changed_paths = _prior_changed_paths(doc) if is_follow_up_mode else []
+        implementation_memory = (
+            (doc.implementation_snapshot or doc.change_summary or "").strip()
+            if is_follow_up_mode else ""
+        )
+        follow_up_message = (doc.follow_up_message or "").strip() if is_follow_up_mode else ""
 
         # Carry the planning-phase stage log into execution for continuity.
         prev_stage_log = _parse_stage_log(doc.stage_log or "")
+
+        repo_root = get_repo_root(app_name)
+        worktree_before = _worktree_signature(repo_root) if is_follow_up_mode else ""
 
         graph = build_execution_graph()
         initial = {
@@ -334,8 +346,11 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
             "intermediate_steps": [],
             "edits_made": [],
             "stage_log": prev_stage_log,
-            # Continue the running token total from the planning phase.
             "tokens_used": int(doc.tokens_used or 0),
+            "is_follow_up": is_follow_up_mode,
+            "follow_up_message": follow_up_message,
+            "prior_changed_paths": prior_changed_paths,
+            "implementation_memory": implementation_memory,
         }
 
         final_state = graph.invoke(initial)
@@ -357,9 +372,18 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
             _update_status(request_name, user, "Implementing",
                 f"Removed {len(stripped)} stray file(s): {', '.join(stripped[:5])}")
 
+        worktree_after = _worktree_signature(repo_root) if is_follow_up_mode else ""
+        run_made_changes = (not is_follow_up_mode) or (worktree_before != worktree_after)
+
         ok_diff, diff_out = run_git(["diff", "--stat"], cwd=repo_root)
         ok_ut, untracked = run_git(["ls-files", "--others", "--exclude-standard"], cwd=repo_root)
         has_changes = bool((diff_out or "").strip()) or bool((untracked or "").strip())
+
+        if is_follow_up_mode and not run_made_changes:
+            _update_status(request_name, user, "Failed",
+                "Follow-up made no changes. The patch did not modify any files on disk.",
+                error_log="Follow-up produced no net file changes.")
+            return
 
         if not has_changes:
             _update_status(request_name, user, "Failed",
@@ -376,14 +400,24 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
             if e.get("path") not in stripped_set
             and not (e.get("path") and _is_scratch_file(e["path"]))
         ]
+        if is_follow_up_mode:
+            edits = _merge_file_edits(as_json_list(doc.files_changed), edits)
         bench_cmds = _compute_bench_commands(app_name, edits)
+
+        change_summary = (final_state.get("change_summary") or "").strip()
+        if is_follow_up_mode and change_summary:
+            prior_summary = (doc.change_summary or "").strip()
+            if prior_summary:
+                change_summary = f"{prior_summary}\n\n--- Follow-up #{doc.follow_up_count or 1} ---\n{change_summary}"
+
+        _save_implementation_snapshot(request_name, doc, final_state, is_follow_up_mode)
 
         _update_status(
             request_name, user, "Awaiting Bench Approval",
-            f"Implementation complete. {len(bench_cmds)} bench commands need approval.",
+            f"{'Follow-up patch' if is_follow_up_mode else 'Implementation'} complete. {len(bench_cmds)} bench commands need approval.",
             patch_diff=patch_diff,
             files_changed=dump_json_capped(edits),
-            change_summary=(final_state.get("change_summary") or "").strip(),
+            change_summary=change_summary,
             pending_bench_commands=json.dumps(bench_cmds),
             tokens_used=int(final_state.get("tokens_used") or 0),
         )
@@ -397,6 +431,88 @@ def run_execution_phase(request_name: str, preserve_branch: int = 0) -> None:
 # ---------------------------------------------------------------------------
 # Helpers: bench command computation
 # ---------------------------------------------------------------------------
+
+def _worktree_signature(repo_root: str) -> str:
+    """Hash the full working-tree content vs HEAD to detect net file changes.
+
+    Uses content diffs (not just file names) so a follow-up that patches a file
+    already in the changed set is still detected. Includes untracked file
+    contents so newly created files count too.
+    """
+    parts = []
+    # Full content diff of tracked files (staged + unstaged) against HEAD.
+    ok, out = run_git(["diff", "HEAD"], cwd=repo_root)
+    if ok and out:
+        parts.append(out)
+
+    # Untracked files: include their contents, not just their names.
+    ok, untracked = run_git(["ls-files", "--others", "--exclude-standard"], cwd=repo_root)
+    if ok and untracked:
+        for rel in sorted(untracked.splitlines()):
+            rel = rel.strip()
+            if not rel:
+                continue
+            parts.append(f"\n### UNTRACKED {rel}\n")
+            try:
+                with open(os.path.join(repo_root, rel), "r", encoding="utf-8", errors="replace") as fh:
+                    parts.append(fh.read())
+            except OSError:
+                parts.append(f"(unreadable: {rel})")
+
+    payload = "\n".join(parts)
+    return hashlib.sha256(payload.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _prior_changed_paths(doc) -> list:
+    """Canonical paths from the previous run's files_changed list."""
+    paths = []
+    for row in as_json_list(doc.files_changed):
+        if isinstance(row, dict):
+            p = (row.get("path") or "").strip()
+            if p and p not in paths:
+                paths.append(p)
+    return paths
+
+
+def _merge_file_edits(prior: list, new: list) -> list:
+    """Merge prior and new edit records, updating summaries for same paths."""
+    merged = [dict(e) for e in prior if isinstance(e, dict)]
+    index = {e.get("path"): i for i, e in enumerate(merged) if e.get("path")}
+    for entry in new:
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("path")
+        if path and path in index:
+            merged[index[path]]["summary"] = entry.get("summary", merged[index[path]].get("summary"))
+        elif path:
+            merged.append(dict(entry))
+            index[path] = len(merged) - 1
+        else:
+            merged.append(dict(entry))
+    return merged
+
+
+def _save_implementation_snapshot(request_name: str, doc, final_state: dict, is_follow_up: bool):
+    """Remember what this run built so follow-ups can patch instead of re-implement."""
+    summary = (final_state.get("change_summary") or "").strip()
+    edits = final_state.get("edits_made") or []
+    paths = [e.get("path") for e in edits if isinstance(e, dict) and e.get("path")]
+    lines = []
+    if summary:
+        lines.append(summary)
+    if paths:
+        lines.append("\nFiles touched this run:")
+        lines.extend(f"- {p}" for p in paths[:30])
+    snapshot = "\n".join(lines).strip()
+    if not snapshot:
+        return
+    prior = (doc.implementation_snapshot or "").strip()
+    if is_follow_up and prior:
+        snapshot = f"{prior}\n\n--- Follow-up run ---\n{snapshot}"
+    frappe.db.set_value(DOCTYPE_NAME, request_name, {
+        "implementation_snapshot": snapshot[:50000],
+    })
+
 
 # Names/patterns that indicate throwaway "scratch" files the model sometimes
 # creates (progress notes, status markers, metadata dumps). These are never part

--- a/ampower_koda/agent/git_ops.py
+++ b/ampower_koda/agent/git_ops.py
@@ -120,7 +120,7 @@ def push_branch(app_name: str, branch_name: str, repo_url: str, token: str) -> t
     clean_token = (token or "").strip()
     
     if not clean_token:
-        return False, "GitHub token not provided in the AI Agent Request"
+        return False, "GitHub token not provided in the Agent Request"
 
     # Safety check: if it looks like a URL, it's definitely not a token
     if clean_token.startswith("http"):
@@ -227,6 +227,80 @@ def get_current_branch(app_name: str) -> str:
     root = get_repo_root(app_name)
     ok, out = run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
     return out.strip() if ok else ""
+
+
+def run_git_stdout(cmd: list[str], cwd: str | None = None) -> tuple[bool, str]:
+    """Run git and return stdout only (stderr excluded — suitable for diff parsing)."""
+    try:
+        result = subprocess.run(
+            ["git"] + cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return result.returncode == 0, (result.stdout or "")
+    except subprocess.TimeoutExpired:
+        return False, ""
+    except Exception:
+        return False, ""
+
+
+def branch_exists(app_name: str, branch_name: str) -> bool:
+    """Return True if the given branch or ref exists in the repo."""
+    if not branch_name:
+        return False
+    root = get_repo_root(app_name)
+    ok, out = run_git_stdout(["rev-parse", "--verify", branch_name], cwd=root)
+    return ok and bool(out.strip())
+
+
+def list_changed_files(
+    app_name: str, base_branch: str, branch_name: str
+) -> tuple[bool, list[dict]]:
+    """
+    List files changed between base_branch and branch_name.
+    Returns ([{"status": "M|A|D|R", "path": "relative/path"}, ...]).
+    """
+    if not branch_name:
+        return False, []
+    root = get_repo_root(app_name)
+    base = (base_branch or "main").strip()
+    ok, out = run_git_stdout(
+        ["diff", "--name-status", base, branch_name],
+        cwd=root,
+    )
+    if not ok:
+        return False, []
+
+    files = []
+    for line in out.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0][0].upper()
+        path = parts[-1].strip()
+        if path:
+            files.append({"status": status, "path": path})
+    return True, files
+
+
+def diff_file(
+    app_name: str, base_branch: str, branch_name: str, file_path: str
+) -> tuple[bool, str]:
+    """Return unified diff for a single file between base and branch (untruncated)."""
+    if not branch_name or not file_path:
+        return False, ""
+    root = get_repo_root(app_name)
+    base = (base_branch or "main").strip()
+    ok, out = run_git_stdout(
+        ["diff", base, branch_name, "--", file_path],
+        cwd=root,
+    )
+    return ok, out
 
 
 def checkout_base(app_name: str, base_branch: str = "main") -> tuple[bool, str]:

--- a/ampower_koda/agent/git_ops.py
+++ b/ampower_koda/agent/git_ops.py
@@ -8,6 +8,8 @@ import requests as http_requests
 
 import frappe
 
+from ampower_koda.agent.errors import log_agent_error
+
 
 def get_repo_root(app_name: str) -> str:
     """
@@ -36,8 +38,13 @@ def run_git(cmd: list[str], cwd: str | None = None) -> tuple[bool, str]:
         out = ((result.stdout or "").strip() + "\n" + (result.stderr or "").strip()).strip()
         return result.returncode == 0, out
     except subprocess.TimeoutExpired:
+        log_agent_error("Agent Git: command timeout", f"cmd={' '.join(cmd)}\ncwd={cwd}")
         return False, "Git command timed out"
     except Exception as e:
+        log_agent_error(
+            "Agent Git: command failed",
+            f"cmd={' '.join(cmd)}\ncwd={cwd}\n{e}\n{frappe.get_traceback()}",
+        )
         return False, str(e)
 
 
@@ -184,6 +191,10 @@ def create_pull_request(
         msg = data.get("message", resp.text)
         return False, msg, None, None
     except Exception as e:
+        log_agent_error(
+            "Agent Git: create pull request",
+            f"repo={repo_url}\n{e}\n{frappe.get_traceback()}",
+        )
         return False, str(e), None, None
 
 
@@ -201,7 +212,11 @@ def generate_branch_name(request_name: str, branch_prefix: str = "ai-agent/", ap
 
     try:
         root = get_repo_root(app_name)
-    except Exception:
+    except Exception as e:
+        log_agent_error(
+            "Agent Git: generate branch name",
+            f"app={app_name}\n{e}\n{frappe.get_traceback()}",
+        )
         return base_name
 
     ok, branches = run_git(["branch", "--list", "--all"], cwd=root)
@@ -241,8 +256,13 @@ def run_git_stdout(cmd: list[str], cwd: str | None = None) -> tuple[bool, str]:
         )
         return result.returncode == 0, (result.stdout or "")
     except subprocess.TimeoutExpired:
+        log_agent_error("Agent Git: stdout command timeout", f"cmd={' '.join(cmd)}\ncwd={cwd}")
         return False, ""
-    except Exception:
+    except Exception as e:
+        log_agent_error(
+            "Agent Git: stdout command failed",
+            f"cmd={' '.join(cmd)}\ncwd={cwd}\n{e}\n{frappe.get_traceback()}",
+        )
         return False, ""
 
 

--- a/ampower_koda/agent/graph.py
+++ b/ampower_koda/agent/graph.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-# LangGraph workflows: Planning (Understand -> Plan) and Execution (Implement).
-# A local syntax check gates the implement pass; bench and deploy run in executor.py.
+# LangGraph workflows: Planning (Understand -> Plan) and Execution (Implement -> Review).
+# A local syntax check gates the implement pass; review validates clean code/Frappe
+# standards before bench and deploy run in executor.py.
 
 import os
 import re as _re
@@ -20,13 +21,17 @@ from ampower_koda.agent.prompts import (
     get_understand_prompt,
     get_plan_prompt,
     get_implement_prompt,
+    get_follow_up_implement_prompt,
+    get_review_prompt,
 )
 
 
 MAX_TOOL_ROUNDS_PLANNING = 40
 MAX_TOOL_ROUNDS_EXECUTION = 30
+MAX_TOOL_ROUNDS_REVIEW = 6        # keep review short to limit token usage
 MAX_TOOL_ROUNDS_SYNTAX_FIX = 12   # rounds for a focused "fix the syntax errors" pass
 MAX_SYNTAX_FIX_ATTEMPTS = 2       # how many times to re-invoke to fix remaining syntax errors
+MAX_REVIEW_ATTEMPTS = 2           # implement + review retries before failing
 WRITE_TOOLS = {"replace_lines", "insert_lines", "edit_file", "write_file"}
 
 # Per-phase output stored in conversation_log. High so full phase text is retained
@@ -74,6 +79,21 @@ def _message_content_to_str(content) -> str:
 def _llm_response_text(response) -> str:
     """Extract plain text from a LangChain chat model response."""
     return _message_content_to_str(getattr(response, "content", ""))
+
+
+def _parse_review_verdict(text: str) -> tuple[bool, str]:
+    """Parse explicit review verdict without extra LLM calls."""
+    notes = (text or "").strip()
+    upper = notes.upper()
+    if _re.search(r"REVIEW_PASSED\s*[=:]\s*YES\b", upper):
+        return True, notes
+    if _re.search(r"REVIEW_PASSED\s*[=:]\s*NO\b", upper):
+        return False, notes
+    if "REVIEW_PASSED=YES" in upper or "REVIEW PASSED: YES" in upper:
+        return True, notes
+    if "REVIEW_PASSED=NO" in upper or "REVIEW PASSED: NO" in upper:
+        return False, notes
+    return False, notes or "Review verdict missing explicit REVIEW_PASSED=yes/no."
 
 
 def _syntax_check_edits(app_name: str, edits: list[dict]) -> tuple[bool, str]:
@@ -736,31 +756,67 @@ def plan_node(state: dict) -> dict:
 def implement_node(state: dict) -> dict:
     """Apply the approved plan by editing and creating files with write tools.
 
-    Runs a single implementation pass, then a local syntax check on the edited
-    .py/.js files so broken code never reaches bench. There is no LLM review loop.
+    Runs an implementation pass, then a local syntax check on the edited
+    .py/.js files so broken code never reaches bench. A review stage can
+    send corrections back into a follow-up implement pass.
     """
     if state.get("error"):
         return {"error": state["error"]}
-    logs = _log_stage(state, "Implementing", "started", "Applying code changes")
+    is_follow_up = bool(state.get("is_follow_up"))
+    attempt = (state.get("review_attempts") or 0) + 1
+    logs = _log_stage(
+        state, "Implementing", "started",
+        "Applying follow-up patch" if is_follow_up else f"Applying code changes (attempt {attempt})"
+    )
 
     app_name = state.get("target_app_name", "")
     plan_text = _message_content_to_str(state.get("plan", ""))
     understanding_text = _message_content_to_str(state.get("understanding_summary", ""))
-    all_text = plan_text + "\n" + understanding_text
-    file_paths = _extract_file_paths(all_text)
-    file_contents = _pre_read_files(app_name, file_paths)
-    logs = _log_stage(
-        {**state, "stage_log": logs}, "Implementing", "progress",
-        f"Pre-loaded {len(file_paths)} files: {', '.join(file_paths[:5])}"
-    )
 
-    base_prompt = get_implement_prompt(
-        plan_text,
-        understanding_text,
-        state.get("user_message", ""),
-        file_contents,
-        request_name=state.get("request_name"),
-    )
+    if is_follow_up:
+        follow_up_message = _message_content_to_str(state.get("follow_up_message", ""))
+        prior_paths = list(state.get("prior_changed_paths") or [])
+        implementation_memory = _message_content_to_str(state.get("implementation_memory", ""))
+        context_paths = list(dict.fromkeys(prior_paths + _extract_file_paths(follow_up_message)))
+        file_contents = _pre_read_files(app_name, context_paths)
+        prior_files = "\n".join(f"- {p}" for p in context_paths) if context_paths else "- (none recorded)"
+        logs = _log_stage(
+            {**state, "stage_log": logs}, "Implementing", "progress",
+            f"Follow-up context: {len(context_paths)} files loaded"
+        )
+        base_prompt = get_follow_up_implement_prompt(
+            follow_up_message,
+            plan_text,
+            implementation_memory,
+            prior_files,
+            file_contents,
+            request_name=state.get("request_name"),
+        )
+    else:
+        all_text = plan_text + "\n" + understanding_text
+        file_paths = _extract_file_paths(all_text)
+        file_contents = _pre_read_files(app_name, file_paths)
+        logs = _log_stage(
+            {**state, "stage_log": logs}, "Implementing", "progress",
+            f"Pre-loaded {len(file_paths)} files: {', '.join(file_paths[:5])}"
+        )
+        base_prompt = get_implement_prompt(
+            plan_text,
+            understanding_text,
+            state.get("user_message", ""),
+            file_contents,
+            request_name=state.get("request_name"),
+        )
+        review_notes = (state.get("review_notes") or "").strip()
+        if attempt > 1 and review_notes:
+            base_prompt += f"""
+
+## PRIOR REVIEW FINDINGS — FIX THESE NOW
+The last test stage failed. Fix every issue listed below before doing anything else.
+Focus on the exact files and problems described; do not add new features.
+
+{review_notes}
+"""
 
     updates = _run_agent_turn(state, "Implementing", base_prompt, read_only_tools=False, max_rounds=MAX_TOOL_ROUNDS_EXECUTION)
     if updates.get("error"):
@@ -856,6 +912,60 @@ def implement_node(state: dict) -> dict:
     return updates
 
 
+def review_node(state: dict) -> dict:
+    """Test the implementation for clean code and Frappe standards."""
+    if state.get("error"):
+        return {"error": state["error"]}
+    logs = _log_stage(state, "Reviewing", "started", "Testing implementation quality")
+    edits = state.get("edits_made", [])
+    app_name = state.get("target_app_name", "")
+
+    syntax_ok, syntax_report = _syntax_check_edits(app_name, edits)
+    attempt = (state.get("review_attempts") or 0) + 1
+    if not syntax_ok:
+        updates = {
+            "review_passed": False,
+            "review_notes": syntax_report[:1000],
+            "review_attempts": attempt,
+        }
+        logs = _log_stage(
+            {**state, "stage_log": logs}, "Reviewing", "completed",
+            f"Testing FAILED (syntax): {syntax_report[:120]}"
+        )
+        if attempt >= MAX_REVIEW_ATTEMPTS:
+            updates["error"] = f"Syntax errors remain after {attempt} test attempt(s)."
+        updates["stage_log"] = logs
+        return updates
+
+    prompt = get_review_prompt(edits, state.get("user_message", ""), request_name=state.get("request_name"))
+    if syntax_report:
+        short_report = "\n".join(syntax_report.splitlines()[:6])
+        prompt += (
+            "\n\n## LOCAL SYNTAX PRE-CHECK (already passed)\n"
+            f"{short_report}\n"
+            "Do not re-run validate_code unless you need to re-check after reasoning."
+        )
+    updates = _run_agent_turn(state, "Reviewing", prompt, read_only_tools=True, max_rounds=MAX_TOOL_ROUNDS_REVIEW)
+    if updates.get("error"):
+        logs = _log_stage({**state, "stage_log": logs}, "Reviewing", "failed", updates["error"][:200])
+        updates["stage_log"] = logs
+        return updates
+
+    steps = updates.get("intermediate_steps") or []
+    last_out = _message_content_to_str(steps[-1].get("output", "") if steps else "")
+    passed, notes = _parse_review_verdict(last_out)
+    updates["review_passed"] = passed
+    updates["review_notes"] = notes[:1200]
+    updates["review_attempts"] = attempt
+
+    result_msg = "Testing PASSED" if passed else f"Testing FAILED: {notes[:100]}"
+    logs = _log_stage({**state, "stage_log": logs}, "Reviewing", "completed", result_msg)
+    if not passed and attempt >= MAX_REVIEW_ATTEMPTS:
+        updates["error"] = f"Review failed after {attempt} attempt(s)."
+    updates["stage_log"] = logs
+    return updates
+
+
 def _get_bench_env() -> dict:
     """Build a subprocess environment with the correct Node.js on PATH.
     nvm installs Node under ~/.nvm/versions/node/<version>/bin but background
@@ -876,6 +986,20 @@ def _get_bench_env() -> dict:
                 env["PATH"] = bin_dir + os.pathsep + env.get("PATH", "")
                 break
     return env
+
+
+# ---------------------------------------------------------------------------
+# Conditional edge
+# ---------------------------------------------------------------------------
+
+def should_retry_implement(state: dict) -> str:
+    if state.get("error"):
+        return "done"
+    if state.get("review_passed"):
+        return "done"
+    if (state.get("review_attempts") or 0) >= MAX_REVIEW_ATTEMPTS:
+        return "done"
+    return "implement"
 
 
 # ---------------------------------------------------------------------------
@@ -901,12 +1025,17 @@ def build_planning_graph():
 def build_execution_graph():
     """
     Constructs the state machine for the Implementation Phase.
-    Flow: Implement Changes (with a local syntax gate) → END.
+    Flow: Implement Changes → Review/Testing → (Retry if needed).
     """
     workflow = StateGraph(AgentState)
     workflow.add_node("implement", implement_node)
+    workflow.add_node("review", review_node)
 
     workflow.set_entry_point("implement")
-    workflow.add_edge("implement", END)
+    workflow.add_edge("implement", "review")
+    workflow.add_conditional_edges("review", should_retry_implement, {
+        "implement": "implement",
+        "done": END,
+    })
 
     return workflow.compile()

--- a/ampower_koda/agent/graph.py
+++ b/ampower_koda/agent/graph.py
@@ -1,12 +1,10 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-# LangGraph workflows: Planning (Understand→Plan) and Execution (Implement→Review→Bench→Deploy)
+# LangGraph workflows: Planning (Understand -> Plan) and Execution (Implement -> Review).
+# The bench and deploy steps run in executor.py, not in the graph.
 
-import json
 import os
 import re as _re
-import subprocess
 from datetime import datetime
-from functools import partial
 
 import frappe
 from langchain_core.tools import tool
@@ -14,6 +12,7 @@ from langchain_core.messages import HumanMessage, ToolMessage
 from langgraph.graph import END, StateGraph
 from langchain_openai import ChatOpenAI
 
+from ampower_koda.agent.errors import log_agent_error
 from ampower_koda.agent.state import AgentState
 from ampower_koda.agent import tools as agent_tools
 from ampower_koda.agent.prompts import (
@@ -22,15 +21,6 @@ from ampower_koda.agent.prompts import (
     get_plan_prompt,
     get_implement_prompt,
     get_review_prompt,
-)
-from ampower_koda.agent.git_ops import (
-    create_branch,
-    commit_changes,
-    push_branch,
-    create_pull_request,
-    generate_branch_name,
-    run_git,
-    get_repo_root,
 )
 
 
@@ -120,10 +110,7 @@ def _openai_uses_responses_api(model: str) -> bool:
 
 
 def _get_llm(provider: str = "OpenAI", model: str = "gpt-4o-mini"):
-    """
-    Factory function to initialize the appropriate Large Language Model (LLM) 
-    based on the user's preferred provider and model.
-    """
+    """Build the chat model for the given provider and model."""
     provider = (provider or "OpenAI").strip()
     model = (model or "gpt-4o-mini").strip()
     if provider == "Gemini":
@@ -133,7 +120,10 @@ def _get_llm(provider: str = "OpenAI", model: str = "gpt-4o-mini"):
         from langchain_anthropic import ChatAnthropic
         return ChatAnthropic(model=model, temperature=0)
     if provider not in ("OpenAI", "Gemini", "Claude"):
-        frappe.log_error(f"Unknown AI provider '{provider}', defaulting to OpenAI", "Agent LLM Warning")
+        log_agent_error(
+            "Agent LLM Warning",
+            f"Unknown AI provider '{provider}', defaulting to OpenAI",
+        )
     openai_kwargs = {"model": model, "temperature": 0}
     if _openai_uses_responses_api(model):
         openai_kwargs["use_responses_api"] = True
@@ -216,7 +206,10 @@ def _log_stage(state: dict, stage: str, status: str, summary: str) -> list:
                 "message": summary[:200],
             }, user=user)
         except Exception:
-            pass
+            log_agent_error(
+                "Agent Graph: stage log persist",
+                f"request={request_name}\nstage={stage}\n{frappe.get_traceback()}",
+            )
 
     return logs
 
@@ -235,12 +228,10 @@ def _publish_agent_log(request_name: str, log_type: str, **kwargs):
         }
         frappe.publish_realtime("agent_log", payload, user=user)
     except Exception:
-        pass
-
-
-# ---------------------------------------------------------------------------
-# Tool builders — closure over app_name
-# ---------------------------------------------------------------------------
+        log_agent_error(
+            "Agent Graph: publish agent_log",
+            f"request={request_name}\ntype={log_type}\n{frappe.get_traceback()}",
+        )
 
 def _make_tools(app_name: str, read_only: bool = False):
     """Build LangChain tools bound to a specific app_name."""
@@ -379,6 +370,10 @@ def _run_tool_calling_loop(llm, tools, prompt: str, request_name: str = "", max_
                     if len(result) > 15000:
                         result = result[:15000] + "\n... (truncated)"
                 except Exception as e:
+                    log_agent_error(
+                        f"Agent Graph: tool {tc['name']}",
+                        f"request={request_name}\n{e}\n{frappe.get_traceback()}",
+                    )
                     result = f"Tool error: {e}"
             else:
                 result = f"Unknown tool: {tc['name']}"
@@ -439,6 +434,10 @@ def _run_agent_turn(state: dict, phase: str, prompt: str, read_only_tools: bool,
             result["_tool_edited_paths"] = tool_edited_paths
         return result
     except Exception as e:
+        log_agent_error(
+            f"Agent Graph: {phase}",
+            f"request={state.get('request_name')}\n{e}\n{frappe.get_traceback()}",
+        )
         steps = list(state.get("intermediate_steps") or []) + [
             {"phase": phase, "output": f"Error: {e}"}
         ]
@@ -454,11 +453,7 @@ def _run_agent_turn(state: dict, phase: str, prompt: str, read_only_tools: bool,
 # ---------------------------------------------------------------------------
 
 def understand_node(state: dict) -> dict:
-    """
-    The 'Understanding' node. Here, the agent explores the codebase to build 
-     a comprehensive mental model of the relevant files and logic before 
-     attempting any planning.
-    """
+    """Explore the codebase with read-only tools to gather context for planning."""
     if state.get("error"):
         return {"error": state["error"]}
     logs = _log_stage(state, "Understanding", "started", "Exploring codebase to understand the request")
@@ -467,7 +462,7 @@ def understand_node(state: dict) -> dict:
         state.get("request_type", "Improvement"),
         request_name=state.get("request_name"),
     )
-    # The agent is given read-only tools for this phase to ensure a safe exploration.
+    # Read-only tools keep exploration side-effect free.
     updates = _run_agent_turn(state, "Understanding", prompt, read_only_tools=True, max_rounds=MAX_TOOL_ROUNDS_PLANNING)
     if updates.get("error"):
         logs = _log_stage({**state, "stage_log": logs}, "Understanding", "failed", updates["error"][:200])
@@ -482,10 +477,7 @@ def understand_node(state: dict) -> dict:
 
 
 def plan_node(state: dict) -> dict:
-    """
-    The 'Planning' node. The agent synthesizes its discoveries from the 
-    Understanding phase into a concrete, step-by-step implementation plan.
-    """
+    """Turn the understanding summary into a step-by-step implementation plan."""
     if state.get("error"):
         return {"error": state["error"]}
 
@@ -537,6 +529,10 @@ def plan_node(state: dict) -> dict:
             "stage_log": logs,
         }
     except Exception as e:
+        log_agent_error(
+            "Agent Graph: Planning",
+            f"request={state.get('request_name')}\n{e}\n{frappe.get_traceback()}",
+        )
         logs = _log_stage({**state, "stage_log": logs}, "Planning", "failed", str(e)[:200])
         return {
             "current_stage": "Planning",
@@ -550,10 +546,7 @@ def plan_node(state: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 def implement_node(state: dict) -> dict:
-    """
-    The 'Implementing' node. In this phase, the agent applies the approved plan 
-    by writing code and creating new files as needed.
-    """
+    """Apply the approved plan by editing and creating files with write tools."""
     if state.get("error"):
         return {"error": state["error"]}
     attempt = (state.get("review_attempts") or 0) + 1
@@ -618,10 +611,7 @@ You MUST fix ALL of these issues in this attempt. Read the affected files first 
 
 
 def review_node(state: dict) -> dict:
-    """
-    The 'Reviewing' node. The agent takes an adversarial look at its own 
-    implementation to identify potential bugs, syntax errors, or missed requirements.
-    """
+    """Validate the edits (syntax first, then a scoped LLM review) and set the verdict."""
     if state.get("error"):
         return {"error": state["error"]}
     logs = _log_stage(state, "Reviewing", "started", "Testing implemented changes")
@@ -689,175 +679,6 @@ def _get_bench_env() -> dict:
                 env["PATH"] = bin_dir + os.pathsep + env.get("PATH", "")
                 break
     return env
-
-
-def bench_node(state: dict) -> dict:
-    """
-    The 'Building' node. This node executes the necessary bench commands 
-    (like migrations or asset builds) to integrate the changes into the site.
-    """
-    if state.get("error"):
-        return {"error": state["error"]}
-    logs = _log_stage(state, "Building", "started", "Running bench commands to apply changes")
-
-    edits = state.get("edits_made", [])
-    edited_paths = [e.get("path", "") for e in edits if e.get("path")]
-    app_name = state.get("target_app_name", "")
-    request_name = state.get("request_name", "")
-
-    bench_root = os.path.join(frappe.get_app_path("frappe"), "..", "..", "..")
-    bench_root = os.path.normpath(bench_root)
-
-    site_name = frappe.local.site
-    bench_env = _get_bench_env()
-
-    has_doctype_changes = any(
-        p.endswith(".json") and "/doctype/" in p for p in edited_paths
-    )
-    has_js_css_changes = any(
-        p.endswith((".js", ".css", ".html")) for p in edited_paths
-    )
-
-    cmds = []
-    if has_doctype_changes:
-        cmds.append(f"bench --site {site_name} migrate")
-    if has_js_css_changes:
-        cmds.append(f"bench build --app {app_name}")
-    cmds.append(f"bench --site {site_name} clear-cache")
-    cmds.append("supervisorctl restart all")
-
-    bench_output_parts = []
-    for cmd in cmds:
-        _log_stage({**state, "stage_log": logs}, "Building", "progress", f"Running: {cmd}")
-        _publish_agent_log(request_name, "bench_command", command=cmd)
-        try:
-            result = subprocess.run(
-                cmd.split(),
-                cwd=bench_root,
-                capture_output=True,
-                text=True,
-                timeout=900,
-                env=bench_env,
-            )
-            output = (result.stdout or "") + (result.stderr or "")
-            success = result.returncode == 0
-            status_str = "OK" if success else f"FAILED (exit {result.returncode})"
-            entry = f"$ {cmd}\n{status_str}\n{output.strip()}\n"
-            bench_output_parts.append(entry)
-            _publish_agent_log(request_name, "bench_result",
-                command=cmd,
-                success=success,
-                output_preview=output[:500],
-            )
-        except subprocess.TimeoutExpired:
-            entry = f"$ {cmd}\nTIMEOUT after 900s\n"
-            bench_output_parts.append(entry)
-            _publish_agent_log(request_name, "bench_result",
-                command=cmd, success=False, output_preview="Timed out after 900s")
-        except Exception as e:
-            entry = f"$ {cmd}\nERROR: {e}\n"
-            bench_output_parts.append(entry)
-
-    bench_log = "\n".join(bench_output_parts)
-
-    if request_name:
-        try:
-            frappe.db.set_value(DOCTYPE_NAME, request_name, "bench_log", bench_log[:50000])
-            frappe.db.commit()
-        except Exception:
-            pass
-
-    logs = _log_stage({**state, "stage_log": logs}, "Building", "completed",
-        f"Ran {len(cmds)} bench commands")
-    return {
-        "current_stage": "Building",
-        "bench_log": bench_log,
-        "stage_log": logs,
-    }
-
-
-def deploy_node(state: dict) -> dict:
-    """
-    The 'Pushing' node. Finalizes the work by committing the changes to a branch, 
-    pushing to the remote repository, and optionally opening a pull request.
-    """
-    if state.get("error"):
-        return {"error": state["error"]}
-    logs = _log_stage(state, "Pushing", "started", "Creating branch, committing, pushing and opening PR")
-
-    app_name = state.get("target_app_name", "")
-    request_name = state.get("request_name", "AGENT-0000")
-    request_type = state.get("request_type", "Improvement")
-    plan = state.get("plan", "")
-    user_message = state.get("user_message", "")[:500]
-    base_branch = state.get("base_branch", "main")
-    branch_prefix = state.get("branch_prefix", "ai-agent/")
-    repo_url = state.get("github_repo_url", "")
-    token = state.get("github_token", "")
-    git_user_name = state.get("git_user_name", "AI Agent")
-    git_user_email = state.get("git_user_email", "ai-agent@ampower.com")
-
-    branch_name = generate_branch_name(request_name, branch_prefix)
-
-    repo_root = get_repo_root(app_name)
-    ok, diff_out = run_git(["diff", "--stat", "HEAD"], cwd=repo_root)
-    ok2, untracked = run_git(["ls-files", "--others", "--exclude-standard"], cwd=repo_root)
-    has_changes = bool((diff_out or "").strip()) or bool((untracked or "").strip())
-    if not has_changes:
-        logs = _log_stage({**state, "stage_log": logs}, "Pushing", "failed",
-            "No file changes detected on disk. The implement phase did not produce any actual edits.")
-        return {
-            "current_stage": "Pushing",
-            "error": "No code changes were produced. The implement phase did not modify any files on disk.",
-            "branch_name": "",
-            "stage_log": logs,
-        }
-
-    logs = _log_stage({**state, "stage_log": logs}, "Pushing", "progress",
-        f"Verified file changes exist: {(diff_out or untracked or '')[:100]}")
-
-    ok, msg = create_branch(app_name, branch_name, base_branch)
-    if not ok:
-        logs = _log_stage({**state, "stage_log": logs}, "Pushing", "failed", f"Branch creation failed: {msg[:150]}")
-        return {"current_stage": "Pushing", "error": f"create_branch: {msg}", "branch_name": branch_name, "stage_log": logs}
-
-    logs = _log_stage({**state, "stage_log": logs}, "Pushing", "progress", f"Branch created: {branch_name}")
-
-    commit_msg = f"[AI Agent] {request_type}: {request_name}\n\n{user_message[:200]}"
-    ok, msg = commit_changes(app_name, commit_msg, git_user_name, git_user_email)
-    if not ok:
-        if "No changes" in msg:
-            logs = _log_stage({**state, "stage_log": logs}, "Pushing", "failed",
-                "No files were actually changed. The implement phase edits may have all failed.")
-            return {"current_stage": "Pushing", "error": "No code changes were produced.", "branch_name": branch_name, "stage_log": logs}
-        logs = _log_stage({**state, "stage_log": logs}, "Pushing", "failed", f"Commit failed: {msg[:150]}")
-        return {"current_stage": "Pushing", "error": f"commit: {msg}", "branch_name": branch_name, "stage_log": logs}
-
-    logs = _log_stage({**state, "stage_log": logs}, "Pushing", "progress", "Changes committed")
-
-    ok, msg = push_branch(app_name, branch_name, repo_url, token)
-    if not ok:
-        logs = _log_stage({**state, "stage_log": logs}, "Pushing", "failed", f"Push failed: {msg[:150]}")
-        return {"current_stage": "Pushing", "error": f"push: {msg}", "branch_name": branch_name, "stage_log": logs}
-
-    logs = _log_stage({**state, "stage_log": logs}, "Pushing", "progress", "Branch pushed to remote")
-
-    pr_title = f"[AI Agent] {request_type}: {request_name}"
-    pr_body = f"## Request\n{user_message}\n\n## Plan\n{plan}"
-    ok, msg, pr_url, pr_number = create_pull_request(pr_title, pr_body, branch_name, repo_url, token, base_branch)
-    if not ok:
-        logs = _log_stage({**state, "stage_log": logs}, "Pushing", "failed", f"PR creation failed: {msg[:150]}")
-        return {"current_stage": "Pushing", "error": f"PR: {msg}", "branch_name": branch_name, "pr_url": None, "pr_number": None, "stage_log": logs}
-
-    logs = _log_stage({**state, "stage_log": logs}, "Pushing", "completed", f"PR #{pr_number} created: {pr_url}")
-    return {
-        "current_stage": "Completed",
-        "branch_name": branch_name,
-        "pr_url": pr_url,
-        "pr_number": pr_number,
-        "error": None,
-        "stage_log": logs,
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/ampower_koda/agent/graph.py
+++ b/ampower_koda/agent/graph.py
@@ -39,12 +39,85 @@ MAX_TOOL_ROUNDS_EXECUTION = 30
 MAX_TOOL_ROUNDS_REVIEW = 10
 WRITE_TOOLS = {"replace_lines", "insert_lines", "edit_file", "write_file"}
 
-DOCTYPE_NAME = "AI Agent Request"
+DOCTYPE_NAME = "Agent Request"
+
+
+def _message_content_to_str(content) -> str:
+    """Normalize AIMessage content to plain text (Responses API returns list blocks)."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                elif block.get("type") == "refusal" and block.get("refusal"):
+                    parts.append(str(block["refusal"]))
+            else:
+                text = getattr(block, "text", None)
+                if text:
+                    parts.append(str(text))
+        return "".join(parts)
+    return str(content)
+
+
+def _llm_response_text(response) -> str:
+    """Extract plain text from a LangChain chat model response."""
+    return _message_content_to_str(getattr(response, "content", ""))
+
+
+def _parse_review_verdict(text: str) -> tuple[bool, str]:
+    """Parse explicit testing verdict from review output without an extra LLM call."""
+    notes = (text or "").strip()
+    upper = notes.upper()
+    if _re.search(r"REVIEW_PASSED\s*[=:]\s*YES\b", upper):
+        return True, notes
+    if _re.search(r"REVIEW_PASSED\s*[=:]\s*NO\b", upper):
+        return False, notes
+    if "REVIEW_PASSED=YES" in upper or "REVIEW PASSED: YES" in upper:
+        return True, notes
+    if "REVIEW_PASSED=NO" in upper or "REVIEW PASSED: NO" in upper:
+        return False, notes
+    return False, notes or "Testing verdict missing explicit REVIEW_PASSED=yes/no."
+
+
+def _syntax_check_edits(app_name: str, edits: list[dict]) -> tuple[bool, str]:
+    """Validate edited .py/.js locally before spending an LLM review turn."""
+    paths = [e.get("path", "") for e in (edits or []) if e.get("path")]
+    code_paths = [p for p in paths if p.endswith((".py", ".js"))]
+    if not code_paths:
+        return True, ""
+
+    failures = []
+    summary_lines = []
+    for path in code_paths:
+        result = agent_tools.validate_code(app_name, path)
+        first_line = (result or "").split("\n", 1)[0][:240]
+        summary_lines.append(f"- {path}: {first_line}")
+        if "SYNTAX_ERROR" in result or "VALIDATION_FAILED" in result:
+            failures.append(result)
+
+    summary = "\n".join(summary_lines)
+    if failures:
+        return False, "\n\n".join(failures)
+    return True, summary
 
 
 # ---------------------------------------------------------------------------
 # LLM factory — supports OpenAI and Gemini
 # ---------------------------------------------------------------------------
+
+def _openai_uses_responses_api(model: str) -> bool:
+    """Codex and newer pro models require OpenAI's /v1/responses endpoint."""
+    name = (model or "").lower()
+    return "codex" in name or "gpt-5.2-pro" in name or name.startswith("gpt-5.4")
+
 
 def _get_llm(provider: str = "OpenAI", model: str = "gpt-4o-mini"):
     """
@@ -61,7 +134,10 @@ def _get_llm(provider: str = "OpenAI", model: str = "gpt-4o-mini"):
         return ChatAnthropic(model=model, temperature=0)
     if provider not in ("OpenAI", "Gemini", "Claude"):
         frappe.log_error(f"Unknown AI provider '{provider}', defaulting to OpenAI", "Agent LLM Warning")
-    return ChatOpenAI(model=model, temperature=0)
+    openai_kwargs = {"model": model, "temperature": 0}
+    if _openai_uses_responses_api(model):
+        openai_kwargs["use_responses_api"] = True
+    return ChatOpenAI(**openai_kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +355,7 @@ def _run_tool_calling_loop(llm, tools, prompt: str, request_name: str = "", max_
                 tokens_total=total_tokens,
             )
 
-        response_text = getattr(response, "content", "") or ""
+        response_text = _llm_response_text(response)
         if response_text:
             _publish_agent_log(request_name, "llm_response",
                 preview=response_text[:4000],
@@ -324,7 +400,7 @@ def _run_tool_calling_loop(llm, tools, prompt: str, request_name: str = "", max_
     usage = getattr(final, "usage_metadata", None)
     if usage:
         total_tokens += int(usage.get("total_tokens") or 0)
-    return (getattr(final, "content", "") or ""), edited_paths, total_tokens
+    return _llm_response_text(final), edited_paths, total_tokens
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +425,7 @@ def _run_agent_turn(state: dict, phase: str, prompt: str, read_only_tools: bool,
             max_rounds=max_rounds,
             state=state,      
         )
+        content = _message_content_to_str(content)
         max_output = 30000 if phase in ("Understanding", "Planning") else 8000
         steps = list(state.get("intermediate_steps") or []) + [
             {"phase": phase, "output": (content[:max_output] if content else "")}
@@ -397,7 +474,7 @@ def understand_node(state: dict) -> dict:
         updates["stage_log"] = logs
         return updates
     steps = updates.get("intermediate_steps") or []
-    summary = steps[-1].get("output", "") if steps else ""
+    summary = _message_content_to_str(steps[-1].get("output", "") if steps else "")
     updates["understanding_summary"] = summary
     logs = _log_stage({**state, "stage_log": logs}, "Understanding", "completed", summary[:200])
     updates["stage_log"] = logs
@@ -419,7 +496,7 @@ def plan_node(state: dict) -> dict:
         model = state.get("ai_model", "gpt-4o-mini")
         app_name = state.get("target_app_name", "target_app")
         request_name = state.get("request_name", "")
-        understanding = state.get("understanding_summary", "")
+        understanding = _message_content_to_str(state.get("understanding_summary", ""))
         user_message = state.get("user_message", "")
 
         if not understanding.strip():
@@ -436,7 +513,7 @@ def plan_node(state: dict) -> dict:
             preview="Generating detailed plan from codebase analysis...", round=1)
 
         response = llm.invoke([HumanMessage(content=full_prompt)])
-        plan = getattr(response, "content", "") or ""
+        plan = _llm_response_text(response)
 
         if not plan.strip():
             logs = _log_stage({**state, "stage_log": logs}, "Planning", "failed",
@@ -483,7 +560,9 @@ def implement_node(state: dict) -> dict:
     logs = _log_stage(state, "Implementing", "started", f"Applying code changes (attempt {attempt})")
 
     app_name = state.get("target_app_name", "")
-    all_text = (state.get("plan", "") + "\n" + state.get("understanding_summary", ""))
+    plan_text = _message_content_to_str(state.get("plan", ""))
+    understanding_text = _message_content_to_str(state.get("understanding_summary", ""))
+    all_text = plan_text + "\n" + understanding_text
     file_paths = _extract_file_paths(all_text)
     file_contents = _pre_read_files(app_name, file_paths)
     logs = _log_stage(
@@ -492,8 +571,8 @@ def implement_node(state: dict) -> dict:
     )
 
     base_prompt = get_implement_prompt(
-        state.get("plan", ""),
-        state.get("understanding_summary", ""),
+        plan_text,
+        understanding_text,
         state.get("user_message", ""),
         file_contents,
         request_name=state.get("request_name"),
@@ -545,9 +624,32 @@ def review_node(state: dict) -> dict:
     """
     if state.get("error"):
         return {"error": state["error"]}
-    logs = _log_stage(state, "Reviewing", "started", "Reviewing implemented changes")
+    logs = _log_stage(state, "Reviewing", "started", "Testing implemented changes")
     edits = state.get("edits_made", [])
+    app_name = state.get("target_app_name", "")
+
+    syntax_ok, syntax_report = _syntax_check_edits(app_name, edits)
+    if not syntax_ok:
+        updates = {
+            "review_passed": False,
+            "review_notes": syntax_report[:500],
+            "review_attempts": (state.get("review_attempts") or 0) + 1,
+        }
+        logs = _log_stage(
+            {**state, "stage_log": logs}, "Reviewing", "completed",
+            f"Testing FAILED (syntax): {syntax_report[:100]}"
+        )
+        updates["stage_log"] = logs
+        return updates
+
     prompt = get_review_prompt(edits, state.get("user_message", ""), request_name=state.get("request_name"))
+    if syntax_report:
+        prompt += (
+            "\n\n## SYNTAX PRE-CHECK (already validated locally)\n"
+            f"{syntax_report}\n"
+            "Do not call validate_code unless you need to re-check after reasoning. "
+            "Focus on request scope, wiring, and regressions, then give REVIEW_PASSED=yes/no."
+        )
     updates = _run_agent_turn(state, "Reviewing", prompt, read_only_tools=True, max_rounds=MAX_TOOL_ROUNDS_REVIEW)
     if updates.get("error"):
         logs = _log_stage({**state, "stage_log": logs}, "Reviewing", "failed", updates["error"][:200])
@@ -555,34 +657,13 @@ def review_node(state: dict) -> dict:
         return updates
 
     steps = updates.get("intermediate_steps") or []
-    last_out = (steps[-1].get("output", "") if steps else "")
+    last_out = _message_content_to_str(steps[-1].get("output", "") if steps else "")
 
-    if "REVIEW_PASSED" not in last_out.upper():
-        try:
-            provider = state.get("ai_provider", "OpenAI")
-            model = state.get("ai_model", "gpt-4o-mini")
-            llm = _get_llm(provider=provider, model=model)
-            verdict_response = llm.invoke([HumanMessage(
-                content=(
-                    "Based on the review you just performed, give your final verdict.\n"
-                    "Reply with EXACTLY one of:\n"
-                    "- REVIEW_PASSED=yes (if all changes are correct)\n"
-                    "- REVIEW_PASSED=no (followed by what's wrong)\n\n"
-                    f"Review output so far: {last_out[:2000]}"
-                )
-            )])
-            verdict = getattr(verdict_response, "content", "") or ""
-            if verdict.strip():
-                last_out = verdict
-        except Exception:
-            pass
-
-    last_out_upper = last_out.upper()
-    passed = "REVIEW_PASSED=YES" in last_out_upper
+    passed, notes = _parse_review_verdict(last_out)
     updates["review_passed"] = passed
-    updates["review_notes"] = last_out[:500]
+    updates["review_notes"] = notes[:500]
     updates["review_attempts"] = (state.get("review_attempts") or 0) + 1
-    result_msg = "Review PASSED" if passed else f"Review FAILED: {last_out[:100]}"
+    result_msg = "Testing PASSED" if passed else f"Testing FAILED: {notes[:100]}"
     logs = _log_stage({**state, "stage_log": logs}, "Reviewing", "completed", result_msg)
     updates["stage_log"] = logs
     return updates

--- a/ampower_koda/agent/graph.py
+++ b/ampower_koda/agent/graph.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 import frappe
 from langchain_core.tools import tool
-from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, StateGraph
 from langchain_openai import ChatOpenAI
 
@@ -28,6 +28,20 @@ MAX_TOOL_ROUNDS_PLANNING = 40
 MAX_TOOL_ROUNDS_EXECUTION = 30
 MAX_TOOL_ROUNDS_REVIEW = 10
 WRITE_TOOLS = {"replace_lines", "insert_lines", "edit_file", "write_file"}
+
+# Per-phase output stored in conversation_log. High so full phase text is retained
+# (phase outputs are LLM summaries and are naturally well under this in practice).
+MAX_PHASE_OUTPUT_CHARS = 60000
+
+# History trimming: keep recent tool rounds verbatim, compact older ones to text.
+# A "round" is one assistant tool-call message plus all of its tool results.
+KEEP_TOOL_ROUNDS = 8          # recent rounds retained in full
+MIN_KEEP_ROUNDS = 3           # never trim below this many, even under char pressure
+TRIM_CHAR_BUDGET = 100000     # approx history chars before char-based trimming kicks in
+COMPACT_RESULT_PREVIEW = 200  # chars of each tool result kept in the compact summary
+
+# Provider-native prompt caching for the stable system prefix (safe no-op when unsupported).
+ENABLE_PROMPT_CACHE = True
 
 DOCTYPE_NAME = "Agent Request"
 
@@ -128,6 +142,30 @@ def _get_llm(provider: str = "OpenAI", model: str = "gpt-4o-mini"):
     if _openai_uses_responses_api(model):
         openai_kwargs["use_responses_api"] = True
     return ChatOpenAI(**openai_kwargs)
+
+
+def _build_system_message(provider: str, system_prompt: str) -> SystemMessage:
+    """Build the system message, adding provider-native prompt caching where supported.
+
+    Anthropic supports an explicit `cache_control` breakpoint on the system block,
+    which caches the large, stable instruction prefix (big cost saver on repeated
+    tool rounds). OpenAI caches stable prefixes automatically, so a plain system
+    message is enough there. Gemini/others fall back to a plain system message.
+    Caching only reduces cost; it never changes model output.
+    """
+    if ENABLE_PROMPT_CACHE and (provider or "").strip() == "Claude":
+        try:
+            return SystemMessage(content=[{
+                "type": "text",
+                "text": system_prompt,
+                "cache_control": {"type": "ephemeral"},
+            }])
+        except Exception:
+            log_agent_error(
+                "Agent Graph: anthropic cache system message",
+                frappe.get_traceback(),
+            )
+    return SystemMessage(content=system_prompt)
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +271,20 @@ def _publish_agent_log(request_name: str, log_type: str, **kwargs):
             f"request={request_name}\ntype={log_type}\n{frappe.get_traceback()}",
         )
 
+def _persist_token_usage(request_name: str, total_tokens: int):
+    """Write the running token total to the request so the form shows live usage."""
+    if not request_name:
+        return
+    try:
+        frappe.db.set_value(DOCTYPE_NAME, request_name, "tokens_used", int(total_tokens or 0))
+        frappe.db.commit()
+    except Exception:
+        log_agent_error(
+            "Agent Graph: persist token usage",
+            f"request={request_name}\n{frappe.get_traceback()}",
+        )
+
+
 def _make_tools(app_name: str, read_only: bool = False):
     """Build LangChain tools bound to a specific app_name."""
 
@@ -313,38 +365,87 @@ def _make_tools(app_name: str, read_only: bool = False):
 # Tool-calling loop with detailed realtime logging
 # ---------------------------------------------------------------------------
 
-def _run_tool_calling_loop(llm, tools, prompt: str, request_name: str = "", max_rounds: int = 20,state: dict = None) -> tuple[str, list[str], int]:
+def _compact_round_summary(round_entry: dict) -> list[str]:
+    """One short line per tool call in a round, for the compacted-history block."""
+    return round_entry.get("summary", [])
+
+
+def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
+                           request_name: str = "", max_rounds: int = 20,
+                           state: dict = None, provider: str = "OpenAI") -> tuple[str, list[str], int]:
     """
     Run a tool-calling loop, publishing every tool call and LLM response via realtime.
     Returns (final_text, list_of_edited_file_paths, total_tokens_used).
 
-    On each round the LLM is invoked with the full message history. If the LLM
-    returns no tool calls, the loop exits early and returns that response as the
-    final text.
+    Context control (token savings without quality loss):
+      - The stable system prompt is a separate, cache-friendly message.
+      - Older tool rounds are compacted to a short text summary while the most
+        recent rounds are kept verbatim, so the model keeps working context but
+        we stop re-sending large, already-consumed tool outputs every round.
 
-    If max_rounds is reached without the LLM stopping, one final llm.invoke()
-    is fired WITHOUT tools bound — this forces a plain text conclusion rather
-    than an infinite loop. Edited paths and token counts collected up to that
-    point are still returned.
+    A "round" is one assistant tool-call message plus all of its tool results;
+    rounds are trimmed atomically so no tool_call_id is ever left dangling.
+
+    If max_rounds is reached without the LLM stopping, one final llm.invoke() is
+    fired WITHOUT tools bound to force a plain-text conclusion.
     """
     tool_map = {t.name: t for t in tools}
     llm_with_tools = llm.bind_tools(tools)
-    messages = [HumanMessage(content=prompt)]
-    edited_paths = []
-    total_tokens = (state or {}).get("tokens_used", 0) # carry forward from prior phases
 
-    for round_num in range(max_rounds):
-        response = llm_with_tools.invoke(messages)
-        messages.append(response)
+    system_msg = _build_system_message(provider, system_prompt)
+    task_msg = HumanMessage(content=task_prompt)
 
+    rounds: list[dict] = []      # each: {"ai": AIMessage, "tools": [ToolMessage], "summary": [str]}
+    compacted: list[str] = []    # summary lines for dropped (older) rounds
+    edited_paths: list[str] = []
+    total_tokens = (state or {}).get("tokens_used", 0)  # carry forward from prior phases
+
+    def build_messages():
+        msgs = [system_msg, task_msg]
+        if compacted:
+            msgs.append(HumanMessage(content=(
+                "## Earlier tool activity (older rounds, summarized to save context)\n"
+                "These tools already ran; re-read a file only if you need details not captured here.\n"
+                + "\n".join(compacted)
+            )))
+        for r in rounds:
+            msgs.append(r["ai"])
+            msgs.extend(r["tools"])
+        return msgs
+
+    def estimate_chars():
+        return sum(len(str(getattr(m, "content", ""))) for r in rounds for m in [r["ai"], *r["tools"]])
+
+    def maybe_trim():
+        trimmed = False
+        while len(rounds) > KEEP_TOOL_ROUNDS:
+            compacted.extend(_compact_round_summary(rounds.pop(0)))
+            trimmed = True
+        while len(rounds) > MIN_KEEP_ROUNDS and estimate_chars() > TRIM_CHAR_BUDGET:
+            compacted.extend(_compact_round_summary(rounds.pop(0)))
+            trimmed = True
+        if trimmed:
+            _publish_agent_log(request_name, "history_trim",
+                kept_rounds=len(rounds),
+                compacted_lines=len(compacted),
+            )
+
+    def account_tokens(response, round_label):
+        nonlocal total_tokens
         usage = getattr(response, "usage_metadata", None)
         if usage:
             total_tokens += int(usage.get("total_tokens") or 0)
             _publish_agent_log(request_name, "token_usage",
-                round=round_num + 1,
+                round=round_label,
                 tokens_this_round=usage.get("total_tokens", 0),
                 tokens_total=total_tokens,
             )
+            _persist_token_usage(request_name, total_tokens)
+
+    for round_num in range(max_rounds):
+        maybe_trim()
+        response = llm_with_tools.invoke(build_messages())
+        account_tokens(response, round_num + 1)
 
         response_text = _llm_response_text(response)
         if response_text:
@@ -356,6 +457,7 @@ def _run_tool_calling_loop(llm, tools, prompt: str, request_name: str = "", max_
         if not getattr(response, "tool_calls", None):
             return response_text, edited_paths, total_tokens
 
+        round_entry = {"ai": response, "tools": [], "summary": []}
         for tc in response.tool_calls:
             _publish_agent_log(request_name, "tool_call",
                 tool_name=tc["name"],
@@ -389,12 +491,20 @@ def _run_tool_calling_loop(llm, tools, prompt: str, request_name: str = "", max_
                 result_preview=result[:500],
                 round=round_num + 1,
             )
-            messages.append(ToolMessage(content=result, tool_call_id=tc["id"]))
+            round_entry["tools"].append(ToolMessage(content=result, tool_call_id=tc["id"]))
 
-    final = llm.invoke(messages)
-    usage = getattr(final, "usage_metadata", None)
-    if usage:
-        total_tokens += int(usage.get("total_tokens") or 0)
+            arg_preview = ", ".join(
+                f"{k}={str(v)[:60]}" for k, v in list(tc.get("args", {}).items())[:3]
+            )
+            round_entry["summary"].append(
+                f"[r{round_num + 1}] {tc['name']}({arg_preview}) -> {result[:COMPACT_RESULT_PREVIEW]}"
+            )
+
+        rounds.append(round_entry)
+
+    maybe_trim()
+    final = llm.invoke(build_messages())
+    account_tokens(final, max_rounds + 1)
     return _llm_response_text(final), edited_paths, total_tokens
 
 
@@ -413,15 +523,15 @@ def _run_agent_turn(state: dict, phase: str, prompt: str, read_only_tools: bool,
         tools = _make_tools(app_name, read_only=read_only_tools)
         llm = _get_llm(provider=provider, model=model)
         system_prompt = get_system_prompt(app_name or "target_app", request_name=request_name)
-        full_prompt = f"{system_prompt}\n\n{prompt}"
         content, tool_edited_paths, total_tokens = _run_tool_calling_loop(
-            llm, tools, full_prompt,
+            llm, tools, system_prompt, prompt,
             request_name=request_name,
             max_rounds=max_rounds,
-            state=state,      
+            state=state,
+            provider=provider,
         )
         content = _message_content_to_str(content)
-        max_output = 30000 if phase in ("Understanding", "Planning") else 8000
+        max_output = MAX_PHASE_OUTPUT_CHARS
         steps = list(state.get("intermediate_steps") or []) + [
             {"phase": phase, "output": (content[:max_output] if content else "")}
         ]
@@ -481,7 +591,7 @@ def plan_node(state: dict) -> dict:
     if state.get("error"):
         return {"error": state["error"]}
 
-    logs = _log_stage(state, "Planning", "started", "Creating detailed implementation plan from codebase analysis")
+    logs = _log_stage(state, "Planning", "started", "Creating todo-based implementation plan")
 
     try:
         provider = state.get("ai_provider", "OpenAI")
@@ -499,13 +609,26 @@ def plan_node(state: dict) -> dict:
         llm = _get_llm(provider=provider, model=model)
         system_prompt = get_system_prompt(app_name, request_name=request_name)
         plan_prompt = get_plan_prompt(understanding, user_message, request_name=request_name)
-        full_prompt = f"{system_prompt}\n\n{plan_prompt}"
 
         _publish_agent_log(request_name, "llm_response",
-            preview="Generating detailed plan from codebase analysis...", round=1)
+            preview="Generating todo-based plan from codebase analysis...", round=1)
 
-        response = llm.invoke([HumanMessage(content=full_prompt)])
+        response = llm.invoke([
+            _build_system_message(provider, system_prompt),
+            HumanMessage(content=plan_prompt),
+        ])
         plan = _llm_response_text(response)
+
+        total_tokens = state.get("tokens_used", 0)
+        usage = getattr(response, "usage_metadata", None)
+        if usage:
+            total_tokens += int(usage.get("total_tokens") or 0)
+            _publish_agent_log(request_name, "token_usage",
+                round=1,
+                tokens_this_round=usage.get("total_tokens", 0),
+                tokens_total=total_tokens,
+            )
+            _persist_token_usage(request_name, total_tokens)
 
         if not plan.strip():
             logs = _log_stage({**state, "stage_log": logs}, "Planning", "failed",
@@ -516,7 +639,7 @@ def plan_node(state: dict) -> dict:
             preview=plan[:500], round=2)
 
         steps = list(state.get("intermediate_steps") or []) + [
-            {"phase": "Planning", "output": plan[:30000]}
+            {"phase": "Planning", "output": plan[:MAX_PHASE_OUTPUT_CHARS]}
         ]
 
         logs = _log_stage({**state, "stage_log": logs}, "Planning", "completed",
@@ -527,6 +650,7 @@ def plan_node(state: dict) -> dict:
             "plan": plan,
             "intermediate_steps": steps,
             "stage_log": logs,
+            "tokens_used": total_tokens,
         }
     except Exception as e:
         log_agent_error(

--- a/ampower_koda/agent/graph.py
+++ b/ampower_koda/agent/graph.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-# LangGraph workflows: Planning (Understand -> Plan) and Execution (Implement -> Review).
-# The bench and deploy steps run in executor.py, not in the graph.
+# LangGraph workflows: Planning (Understand -> Plan) and Execution (Implement).
+# A local syntax check gates the implement pass; bench and deploy run in executor.py.
 
 import os
 import re as _re
@@ -20,13 +20,13 @@ from ampower_koda.agent.prompts import (
     get_understand_prompt,
     get_plan_prompt,
     get_implement_prompt,
-    get_review_prompt,
 )
 
 
 MAX_TOOL_ROUNDS_PLANNING = 40
 MAX_TOOL_ROUNDS_EXECUTION = 30
-MAX_TOOL_ROUNDS_REVIEW = 10
+MAX_TOOL_ROUNDS_SYNTAX_FIX = 12   # rounds for a focused "fix the syntax errors" pass
+MAX_SYNTAX_FIX_ATTEMPTS = 2       # how many times to re-invoke to fix remaining syntax errors
 WRITE_TOOLS = {"replace_lines", "insert_lines", "edit_file", "write_file"}
 
 # Per-phase output stored in conversation_log. High so full phase text is retained
@@ -76,23 +76,8 @@ def _llm_response_text(response) -> str:
     return _message_content_to_str(getattr(response, "content", ""))
 
 
-def _parse_review_verdict(text: str) -> tuple[bool, str]:
-    """Parse explicit testing verdict from review output without an extra LLM call."""
-    notes = (text or "").strip()
-    upper = notes.upper()
-    if _re.search(r"REVIEW_PASSED\s*[=:]\s*YES\b", upper):
-        return True, notes
-    if _re.search(r"REVIEW_PASSED\s*[=:]\s*NO\b", upper):
-        return False, notes
-    if "REVIEW_PASSED=YES" in upper or "REVIEW PASSED: YES" in upper:
-        return True, notes
-    if "REVIEW_PASSED=NO" in upper or "REVIEW PASSED: NO" in upper:
-        return False, notes
-    return False, notes or "Testing verdict missing explicit REVIEW_PASSED=yes/no."
-
-
 def _syntax_check_edits(app_name: str, edits: list[dict]) -> tuple[bool, str]:
-    """Validate edited .py/.js locally before spending an LLM review turn."""
+    """Validate edited .py/.js locally so broken syntax never reaches bench."""
     paths = [e.get("path", "") for e in (edits or []) if e.get("path")]
     code_paths = [p for p in paths if p.endswith((".py", ".js"))]
     if not code_paths:
@@ -102,9 +87,14 @@ def _syntax_check_edits(app_name: str, edits: list[dict]) -> tuple[bool, str]:
     summary_lines = []
     for path in code_paths:
         result = agent_tools.validate_code(app_name, path)
+        # A path that doesn't resolve to a real file is not a syntax error — it's
+        # usually a phantom path parsed from the model's summary text. Skip it.
+        if "Not a file" in result:
+            continue
         first_line = (result or "").split("\n", 1)[0][:240]
         summary_lines.append(f"- {path}: {first_line}")
-        if "SYNTAX_ERROR" in result or "VALIDATION_FAILED" in result:
+        # Only genuine syntax problems should block the run.
+        if "SYNTAX_ERROR" in result:
             failures.append(result)
 
     summary = "\n".join(summary_lines)
@@ -185,6 +175,30 @@ def _extract_file_paths(text: str) -> list[str]:
         for m in _re.finditer(pat, text):
             paths.add(m.group(0))
     return sorted(paths)
+
+
+def _app_file_exists(app_name: str, rel_path: str) -> bool:
+    """True if rel_path resolves to a real file inside the app (best-effort)."""
+    try:
+        return os.path.isfile(agent_tools._resolve_path(app_name, rel_path))
+    except Exception:
+        return False
+
+
+def _extract_change_summary(text: str) -> str:
+    """Pull the plain-English 'SUMMARY OF CHANGES' the model writes at the end.
+
+    Falls back to the trailing prose of the final message if the explicit heading
+    is missing, so the request always shows a readable summary.
+    """
+    text = (text or "").strip()
+    if not text:
+        return ""
+    m = _re.search(r"(?is)summary of changes\s*:?\s*(.+)$", text)
+    summary = (m.group(1) if m else text).strip()
+    # Drop leftover markdown fences / list bullets noise but keep readable text.
+    summary = summary.strip("`").strip()
+    return summary[:4000]
 
 
 def _pre_read_files(app_name: str, paths: list[str], max_files: int = 25) -> str:
@@ -372,7 +386,8 @@ def _compact_round_summary(round_entry: dict) -> list[str]:
 
 def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
                            request_name: str = "", max_rounds: int = 20,
-                           state: dict = None, provider: str = "OpenAI") -> tuple[str, list[str], int]:
+                           state: dict = None, provider: str = "OpenAI",
+                           require_writes: bool = False) -> tuple[str, list[str], int]:
     """
     Run a tool-calling loop, publishing every tool call and LLM response via realtime.
     Returns (final_text, list_of_edited_file_paths, total_tokens_used).
@@ -386,6 +401,11 @@ def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
     A "round" is one assistant tool-call message plus all of its tool results;
     rounds are trimmed atomically so no tool_call_id is ever left dangling.
 
+    When require_writes is set (implementation phase), the loop nudges the model
+    to stop exploring and actually edit files if it reads for too many rounds
+    without writing, or tries to finish without having made any edit. This
+    prevents the "read forever, never write" failure that yields no file changes.
+
     If max_rounds is reached without the LLM stopping, one final llm.invoke() is
     fired WITHOUT tools bound to force a plain-text conclusion.
     """
@@ -397,8 +417,24 @@ def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
 
     rounds: list[dict] = []      # each: {"ai": AIMessage, "tools": [ToolMessage], "summary": [str]}
     compacted: list[str] = []    # summary lines for dropped (older) rounds
+    injected: list = []          # directive nudges appended after the latest round
     edited_paths: list[str] = []
     total_tokens = (state or {}).get("tokens_used", 0)  # carry forward from prior phases
+
+    wrote_anything = False
+    read_only_streak = 0
+    write_nudges = 0
+    MAX_WRITE_NUDGES = 3
+    READ_STREAK_LIMIT = 5
+    NUDGE_TEXT = (
+        "STOP exploring. You have read enough — the files you need are already "
+        "in context (pre-loaded in the instructions and/or from the reads above). "
+        "Do NOT call read_file, search_code, list_directory, get_file_outline or "
+        "read_doctype_schema again unless an edit actually fails. Make the planned "
+        "changes NOW: call replace_lines, insert_lines, edit_file or write_file to "
+        "apply real edits, then validate_code on each changed .py/.js file. Your "
+        "next message MUST include an edit tool call."
+    )
 
     def build_messages():
         msgs = [system_msg, task_msg]
@@ -411,6 +447,7 @@ def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
         for r in rounds:
             msgs.append(r["ai"])
             msgs.extend(r["tools"])
+        msgs.extend(injected)
         return msgs
 
     def estimate_chars():
@@ -455,9 +492,18 @@ def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
             )
 
         if not getattr(response, "tool_calls", None):
+            # Model wants to finish. In the implement phase, don't let it stop
+            # without ever editing a file — push it to actually write.
+            if require_writes and not wrote_anything and write_nudges < MAX_WRITE_NUDGES:
+                write_nudges += 1
+                injected.append(HumanMessage(content=NUDGE_TEXT))
+                _publish_agent_log(request_name, "write_nudge",
+                    round=round_num + 1, attempt=write_nudges, trigger="no_tool_calls")
+                continue
             return response_text, edited_paths, total_tokens
 
         round_entry = {"ai": response, "tools": [], "summary": []}
+        round_had_write = False
         for tc in response.tool_calls:
             _publish_agent_log(request_name, "tool_call",
                 tool_name=tc["name"],
@@ -482,6 +528,8 @@ def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
 
             if tc["name"] in WRITE_TOOLS:
                 if not result.startswith("Tool error:") and not result.startswith("Error:"):
+                    round_had_write = True
+                    wrote_anything = True
                     path_arg = tc.get("args", {}).get("path", "")
                     if path_arg and path_arg not in edited_paths:
                         edited_paths.append(path_arg)
@@ -501,6 +549,21 @@ def _run_tool_calling_loop(llm, tools, system_prompt: str, task_prompt: str,
             )
 
         rounds.append(round_entry)
+
+        # Proactively break analysis-paralysis: if the model keeps only reading
+        # in the implement phase, tell it to start editing.
+        if round_had_write:
+            read_only_streak = 0
+        else:
+            read_only_streak += 1
+        if (require_writes and not wrote_anything
+                and read_only_streak >= READ_STREAK_LIMIT
+                and write_nudges < MAX_WRITE_NUDGES):
+            write_nudges += 1
+            read_only_streak = 0
+            injected.append(HumanMessage(content=NUDGE_TEXT))
+            _publish_agent_log(request_name, "write_nudge",
+                round=round_num + 1, attempt=write_nudges, trigger="read_streak")
 
     maybe_trim()
     final = llm.invoke(build_messages())
@@ -529,6 +592,7 @@ def _run_agent_turn(state: dict, phase: str, prompt: str, read_only_tools: bool,
             max_rounds=max_rounds,
             state=state,
             provider=provider,
+            require_writes=not read_only_tools,
         )
         content = _message_content_to_str(content)
         max_output = MAX_PHASE_OUTPUT_CHARS
@@ -670,11 +734,14 @@ def plan_node(state: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 def implement_node(state: dict) -> dict:
-    """Apply the approved plan by editing and creating files with write tools."""
+    """Apply the approved plan by editing and creating files with write tools.
+
+    Runs a single implementation pass, then a local syntax check on the edited
+    .py/.js files so broken code never reaches bench. There is no LLM review loop.
+    """
     if state.get("error"):
         return {"error": state["error"]}
-    attempt = (state.get("review_attempts") or 0) + 1
-    logs = _log_stage(state, "Implementing", "started", f"Applying code changes (attempt {attempt})")
+    logs = _log_stage(state, "Implementing", "started", "Applying code changes")
 
     app_name = state.get("target_app_name", "")
     plan_text = _message_content_to_str(state.get("plan", ""))
@@ -695,16 +762,6 @@ def implement_node(state: dict) -> dict:
         request_name=state.get("request_name"),
     )
 
-    review_notes = state.get("review_notes", "")
-    if attempt > 1 and review_notes:
-        base_prompt += f"""
-
-## PREVIOUS REVIEW FEEDBACK — FIX THESE ISSUES
-The previous implementation attempt was reviewed and FAILED. Here is what the reviewer found wrong:
-{review_notes}
-
-You MUST fix ALL of these issues in this attempt. Read the affected files first to see the current state."""
-
     updates = _run_agent_turn(state, "Implementing", base_prompt, read_only_tools=False, max_rounds=MAX_TOOL_ROUNDS_EXECUTION)
     if updates.get("error"):
         logs = _log_stage({**state, "stage_log": logs}, "Implementing", "failed", updates["error"][:200])
@@ -713,72 +770,88 @@ You MUST fix ALL of these issues in this attempt. Read the affected files first 
 
     tool_edited = updates.pop("_tool_edited_paths", [])
     steps = updates.get("intermediate_steps") or []
-    last_out = steps[-1].get("output", "") if steps else ""
-    text_paths = _extract_file_paths(last_out)
+    last_out = _message_content_to_str(steps[-1].get("output", "") if steps else "")
+    # Only keep summary-mentioned paths that actually exist on disk — the model
+    # often names files it merely considered, which would otherwise be recorded
+    # as phantom edits and break validation ("Not a file").
+    text_paths = [p for p in _extract_file_paths(last_out) if _app_file_exists(app_name, p)]
 
     all_paths = list(dict.fromkeys(tool_edited + text_paths))
 
     edits = list(state.get("edits_made") or [])
     for p in all_paths:
         if not any(e.get("path") == p for e in edits):
-            edits.append({"path": p, "summary": f"Modified in attempt {attempt}"})
+            edits.append({"path": p, "summary": "Modified"})
     if not all_paths:
         edits.append({"summary": last_out[:300]})
     updates["edits_made"] = edits
+    updates["change_summary"] = _extract_change_summary(last_out)
+
+    logs = _log_stage(
+        {**state, "stage_log": logs}, "Implementing", "progress",
+        f"Files edited: {', '.join(all_paths[:8]) if all_paths else 'see summary'}"
+    )
+
+    # Local syntax gate. If real syntax errors exist, try to auto-fix them by
+    # feeding the exact errors back to the model, then re-check — instead of
+    # failing the whole run on the first broken edit.
+    syntax_ok, syntax_report = _syntax_check_edits(app_name, edits)
+    fix_state = {
+        **state,
+        "tokens_used": updates.get("tokens_used", state.get("tokens_used", 0)),
+        "intermediate_steps": updates.get("intermediate_steps") or [],
+        "stage_log": logs,
+    }
+    attempt = 0
+    while not syntax_ok and attempt < MAX_SYNTAX_FIX_ATTEMPTS:
+        attempt += 1
+        logs = _log_stage(
+            {**state, "stage_log": logs}, "Implementing", "progress",
+            f"Auto-fixing syntax errors (attempt {attempt})"
+        )
+        fix_state["stage_log"] = logs
+        fix_prompt = (
+            "One or more files you just edited have SYNTAX ERRORS. Fix ONLY these "
+            "errors now. For each affected file: read it to see the current state, "
+            "correct the syntax with replace_lines/insert_lines/edit_file, then call "
+            "validate_code on it to confirm it passes. Do NOT change unrelated code "
+            "and do NOT create any new files.\n\n"
+            f"## SYNTAX ERRORS TO FIX\n{syntax_report}"
+        )
+        fix_updates = _run_agent_turn(
+            fix_state, "Implementing", fix_prompt,
+            read_only_tools=False, max_rounds=MAX_TOOL_ROUNDS_SYNTAX_FIX,
+        )
+        # Carry forward token/step accounting whatever the outcome.
+        fix_state["tokens_used"] = fix_updates.get("tokens_used", fix_state["tokens_used"])
+        fix_state["intermediate_steps"] = fix_updates.get("intermediate_steps") or fix_state["intermediate_steps"]
+        updates["tokens_used"] = fix_state["tokens_used"]
+        updates["intermediate_steps"] = fix_state["intermediate_steps"]
+        if fix_updates.get("error"):
+            break
+        for p in fix_updates.pop("_tool_edited_paths", []):
+            if not any(e.get("path") == p for e in edits):
+                edits.append({"path": p, "summary": "Modified (syntax fix)"})
+        updates["edits_made"] = edits
+        syntax_ok, syntax_report = _syntax_check_edits(app_name, edits)
+
+    if not syntax_ok:
+        logs = _log_stage(
+            {**state, "stage_log": logs}, "Implementing", "failed",
+            f"Syntax check failed: {syntax_report[:150]}"
+        )
+        updates["error"] = (
+            "Implementation produced invalid syntax that could not be auto-fixed:\n"
+            f"{syntax_report[:1000]}"
+        )
+        updates["stage_log"] = logs
+        return updates
 
     logs = _log_stage(
         {**state, "stage_log": logs}, "Implementing", "completed",
-        f"Files edited: {', '.join(all_paths[:8]) if all_paths else 'see summary'}"
+        "Changes applied and syntax validated"
+        + (f" (auto-fixed on attempt {attempt})" if attempt else "")
     )
-    updates["stage_log"] = logs
-    return updates
-
-
-def review_node(state: dict) -> dict:
-    """Validate the edits (syntax first, then a scoped LLM review) and set the verdict."""
-    if state.get("error"):
-        return {"error": state["error"]}
-    logs = _log_stage(state, "Reviewing", "started", "Testing implemented changes")
-    edits = state.get("edits_made", [])
-    app_name = state.get("target_app_name", "")
-
-    syntax_ok, syntax_report = _syntax_check_edits(app_name, edits)
-    if not syntax_ok:
-        updates = {
-            "review_passed": False,
-            "review_notes": syntax_report[:500],
-            "review_attempts": (state.get("review_attempts") or 0) + 1,
-        }
-        logs = _log_stage(
-            {**state, "stage_log": logs}, "Reviewing", "completed",
-            f"Testing FAILED (syntax): {syntax_report[:100]}"
-        )
-        updates["stage_log"] = logs
-        return updates
-
-    prompt = get_review_prompt(edits, state.get("user_message", ""), request_name=state.get("request_name"))
-    if syntax_report:
-        prompt += (
-            "\n\n## SYNTAX PRE-CHECK (already validated locally)\n"
-            f"{syntax_report}\n"
-            "Do not call validate_code unless you need to re-check after reasoning. "
-            "Focus on request scope, wiring, and regressions, then give REVIEW_PASSED=yes/no."
-        )
-    updates = _run_agent_turn(state, "Reviewing", prompt, read_only_tools=True, max_rounds=MAX_TOOL_ROUNDS_REVIEW)
-    if updates.get("error"):
-        logs = _log_stage({**state, "stage_log": logs}, "Reviewing", "failed", updates["error"][:200])
-        updates["stage_log"] = logs
-        return updates
-
-    steps = updates.get("intermediate_steps") or []
-    last_out = _message_content_to_str(steps[-1].get("output", "") if steps else "")
-
-    passed, notes = _parse_review_verdict(last_out)
-    updates["review_passed"] = passed
-    updates["review_notes"] = notes[:500]
-    updates["review_attempts"] = (state.get("review_attempts") or 0) + 1
-    result_msg = "Testing PASSED" if passed else f"Testing FAILED: {notes[:100]}"
-    logs = _log_stage({**state, "stage_log": logs}, "Reviewing", "completed", result_msg)
     updates["stage_log"] = logs
     return updates
 
@@ -806,20 +879,6 @@ def _get_bench_env() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Conditional edge
-# ---------------------------------------------------------------------------
-
-def should_retry_implement(state: dict) -> str:
-    if state.get("error"):
-        return "done"
-    if state.get("review_passed"):
-        return "done"
-    if (state.get("review_attempts") or 0) >= 3:
-        return "done"
-    return "implement"
-
-
-# ---------------------------------------------------------------------------
 # Graph builders
 # ---------------------------------------------------------------------------
 
@@ -842,17 +901,12 @@ def build_planning_graph():
 def build_execution_graph():
     """
     Constructs the state machine for the Implementation Phase.
-    Flow: Implement Changes → Review Work → (Retry if needed).
+    Flow: Implement Changes (with a local syntax gate) → END.
     """
     workflow = StateGraph(AgentState)
     workflow.add_node("implement", implement_node)
-    workflow.add_node("review", review_node)
 
     workflow.set_entry_point("implement")
-    workflow.add_edge("implement", "review")
-    workflow.add_conditional_edges("review", should_retry_implement, {
-        "implement": "implement",
-        "done": END,
-    })
+    workflow.add_edge("implement", END)
 
     return workflow.compile()

--- a/ampower_koda/agent/prompts.py
+++ b/ampower_koda/agent/prompts.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
 # System prompts for the AI coding agent — Cursor-inspired, anti-hallucination, production-grade
 
-import re
-
 import frappe
 
 from ampower_koda.agent.errors import log_agent_error
@@ -13,7 +11,6 @@ PROMPT_LABEL_MAP = {
     "understand_prompt": "Understand Prompt",
     "plan_prompt": "Plan Prompt",
     "implement_prompt": "Implement Prompt",
-    "review_prompt": "Review Prompt"
 }
 
 class SafeDict(dict):
@@ -319,36 +316,6 @@ Quote the EXACT code sections (with line numbers) that will need to be modified.
     return render_prompt_safe(template, context, default)
 
 
-def plan_has_open_questions(plan: str) -> bool:
-    """True when the plan lists unanswered Questions for User (not 'None — request is fully clear')."""
-    if not (plan or "").strip():
-        return False
-    match = re.search(
-        r"## Questions for User\s*\n(.*?)(?=\n## |\Z)",
-        plan,
-        re.DOTALL | re.IGNORECASE,
-    )
-    if not match:
-        return False
-    body = match.group(1).strip()
-    if not body:
-        return False
-    lowered = body.lower()
-    clear_markers = (
-        "none — request is fully clear",
-        "none - request is fully clear",
-        "none. request is fully clear",
-        "no open questions",
-        "none — all requirements are clear",
-        "none - all requirements are clear",
-    )
-    if lowered in clear_markers or lowered.startswith("none —") and "fully clear" in lowered:
-        return False
-    if lowered.startswith("none") and len(body.split()) <= 6:
-        return False
-    return True
-
-
 def get_plan_prompt(understanding_summary: str, user_message: str = "", request_name: str = None) -> str:
     user_section = f"## USER REQUEST\n{user_message}\n\n" if user_message else ""
     default = """{user_section}## CODEBASE ANALYSIS
@@ -364,7 +331,7 @@ Your job now is to describe **what** must be done, not **how** in source code.
 
 ### Planning principles (Cursor / Antigravity style)
 1. **Todos, not code** — each item is a clear task with a detailed description and acceptance criteria.
-2. **No assumptions** — if scope, behavior, field names, or UX are unclear from the request or codebase analysis, ask the user in **Questions for User**. Do not guess.
+2. **State assumptions, don't block** — if scope, behavior, field names, or UX are unclear, make the most reasonable choice grounded in the codebase analysis and record it under **Assumptions**. Do not stop to ask the user.
 3. **Ground in analysis** — reference exact file paths and line ranges from the codebase analysis. Quote short excerpts (1–3 lines) only for context, never full replacements.
 4. **Minimal scope** — only tasks required for this request type. No drive-by refactors.
 5. **Exploration is done** — do not add read/inspect/explore tasks.
@@ -381,13 +348,9 @@ Your job now is to describe **what** must be done, not **how** in source code.
 **Out of scope:** bullet list of what is explicitly NOT included (prevents scope creep)
 
 ## Assumptions
-List assumptions you are making based on the codebase analysis.
+List the assumptions and decisions you are making based on the codebase analysis
+(including any ambiguity you resolved on the user's behalf).
 If you have none, write exactly: `None — all requirements verified from codebase analysis.`
-
-## Questions for User
-If ANYTHING is ambiguous, missing, or could be interpreted multiple ways, list numbered questions here.
-Be specific — reference what you found vs what you need.
-If the request is fully clear, write exactly: `None — request is fully clear.`
 
 ## Implementation Todos
 
@@ -431,13 +394,7 @@ Bullet list of potential issues and how to avoid them.
 - **NO** pseudocode or partial functions
 - **NO** "update as needed" or "add appropriate logic"
 - **NO** exploration/read-only tasks
-- **NO** guessing field names, API paths, or behavior — ask in Questions for User instead
-
-### When to ask questions (examples)
-- User request mentions a feature but analysis shows multiple valid places to implement it
-- Required field names or DocType names not found in analysis
-- UX behavior not specified (filters, permissions, defaults)
-- Conflict between user request and existing app patterns
+- **NO** open questions or requests for clarification — resolve ambiguity yourself and record it under Assumptions
 """
     template = get_config_prompt("plan_prompt", default, request_name)
 
@@ -489,12 +446,25 @@ For each TODO:
 - **Match existing app patterns** — copy structure from peer artifacts when creating new ones
 - **NEVER insert code inside JS template literals**
 - **NEVER guess** field names or API paths — read files first
-- List [MODIFIED] and [CREATED] files when done
+- Only edit/create the **code files required by the plan**
+
+### FORBIDDEN — do NOT create these files
+Do NOT create README, CHANGELOG, notes, summary, status, "done", "finalize", or
+metadata files (e.g. `*.md`, `*.txt`, `*_NOTE.txt`, `IMPLEMENTATION_DONE.txt`,
+`FINALIZE_*.txt`, `*_METADATA.txt`, `*_SUMMARY*`). Do NOT write your summary or
+progress notes into a file. The ONLY files you may touch are the actual source
+code files needed to satisfy the plan's todos. Put any explanation in your final
+message text — never in a new file.
 
 ### If problems
 - EDIT_FAILED → re-read file, use fresh line numbers
 - Line numbers shifted → search_code or re-read before retry
 - Todo description conflicts with file contents → follow the file, note in output
+
+### FINAL STEP — write a summary (in your message, not a file)
+After all edits are applied and validated, end with a concise plain-English
+summary titled `SUMMARY OF CHANGES:` — 3–8 sentences describing, per file, what
+you changed and why. Do not include code in the summary.
 """
     template = get_config_prompt("implement_prompt", default, request_name)
 
@@ -503,61 +473,6 @@ For each TODO:
         "understanding_summary": understanding_summary,
         "user_message": user_message,
         "file_contents": file_contents
-    }
-
-    return render_prompt_safe(template, context, default)
-
-
-def get_review_prompt(edits_made: list[dict], user_message: str, request_name: str = None) -> str:
-    paths = [e.get("path", "") for e in edits_made if e.get("path")]
-    paths_list = "\n".join(f"- {p}" for p in paths) if paths else "(no specific paths recorded)"
-
-    default = """## USER REQUEST
-{user_message_short}
-
-## FILES MODIFIED
-{paths_list}
-
-## TESTING INSTRUCTIONS (Frappe)
-
-Test whether the changes **satisfy the USER REQUEST above** and still keep existing behavior stable. Stay within request scope — do not audit fields, files, or features the user did not ask for.
-
-Read each modified file with `read_file(path)`. Call `validate_code(path)` on every .py and .js file.
-
-### Generic testing checklist
-1. **Request scope** — Matches what was asked (bug fixed / report added / feature built)? No unrelated files?
-2. **Syntax** — .py/.js pass validate_code; .json is valid JSON.
-3. **Imports** — frappe, json, datetime imported where used.
-4. **Wiring** — frappe.call ↔ @frappe.whitelist if client↔server; report execute() if Script Report; form handlers if DocType UI.
-5. **Consistency** — fieldnames/method paths match across files touched by THIS change only.
-
-### Testing by task type
-- **Bug fix**: original issue addressed; no scope creep.
-- **Report**: report files work together; don't fail for missing DocType fields unless part of request.
-- **DocType**: schema + controller + client consistent if all were in scope.
-- **Page/API/hook**: artifact loads or runs; hook keys not duplicated.
-
-### JSON — scoped only
-- Read actual file content. No field-by-field metadata audits.
-- Fail only blocking issues: invalid JSON, wrong doctype, missing fields required for THIS request.
-- Accept same metadata pattern as peer artifacts in the app.
-
-### Verdict rules
-- `REVIEW_PASSED=yes` — request implemented, syntax valid, no blocking Frappe bug.
-- `REVIEW_PASSED=no` — only real bugs: syntax errors, broken imports, code inside JS template literals, mismatched fieldnames, or JSON that would break migrate. List **at most 5** issues with concrete fixes.
-
-After reading ALL files, give your verdict IMMEDIATELY.
-
-### VERDICT FORMAT (REQUIRED):
-- All good: `REVIEW_PASSED=yes`
-- Issues found: `REVIEW_PASSED=no` then list each issue:
-  - File: path — Issue: (e.g. Missing import of 'json') — Fix: (e.g. Add import at line 2)
-"""
-    template = get_config_prompt("review_prompt", default, request_name)
-
-    context = {
-        "user_message_short": user_message[:800] if user_message else "",
-        "paths_list": paths_list
     }
 
     return render_prompt_safe(template, context, default)

--- a/ampower_koda/agent/prompts.py
+++ b/ampower_koda/agent/prompts.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
 # System prompts for the AI coding agent — Cursor-inspired, anti-hallucination, production-grade
 
+import re
+
 import frappe
 
 from ampower_koda.agent.errors import log_agent_error
@@ -317,96 +319,125 @@ Quote the EXACT code sections (with line numbers) that will need to be modified.
     return render_prompt_safe(template, context, default)
 
 
+def plan_has_open_questions(plan: str) -> bool:
+    """True when the plan lists unanswered Questions for User (not 'None — request is fully clear')."""
+    if not (plan or "").strip():
+        return False
+    match = re.search(
+        r"## Questions for User\s*\n(.*?)(?=\n## |\Z)",
+        plan,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if not match:
+        return False
+    body = match.group(1).strip()
+    if not body:
+        return False
+    lowered = body.lower()
+    clear_markers = (
+        "none — request is fully clear",
+        "none - request is fully clear",
+        "none. request is fully clear",
+        "no open questions",
+        "none — all requirements are clear",
+        "none - all requirements are clear",
+    )
+    if lowered in clear_markers or lowered.startswith("none —") and "fully clear" in lowered:
+        return False
+    if lowered.startswith("none") and len(body.split()) <= 6:
+        return False
+    return True
+
+
 def get_plan_prompt(understanding_summary: str, user_message: str = "", request_name: str = None) -> str:
     user_section = f"## USER REQUEST\n{user_message}\n\n" if user_message else ""
     default = """{user_section}## CODEBASE ANALYSIS
 {understanding_summary}
 
-## YOUR TASK: Create a Production-Ready Implementation Plan
+## YOUR TASK: Create an Implementation Plan (Todos Only — No Code)
 
-You are writing this plan for an AI agent that will execute it step-by-step. The agent can read files, search code, and make edits — but it needs EXTREMELY precise instructions. Vague plans lead to broken code.
+You are writing a **review plan** for a human to approve before any code is written.
+An implementation agent will execute this plan **after approval** — it will read files and write code then.
+Your job now is to describe **what** must be done, not **how** in source code.
 
-**CRITICAL: Do NOT call any tools. You already have all the codebase information above. Write the plan ONLY.**
+**CRITICAL: Do NOT call any tools. Do NOT write code, pseudocode, or JSON/Python/JS snippets in this plan.**
 
-### RULES FOR EVERY TASK IN THE PLAN
-1. **Every task MUST be an actual code change** — exploration is DONE.
-2. **Scope to the request type** — only the files needed for that category.
-3. **Reference exact line numbers** for MODIFY tasks.
-4. **Show complete code** — actual Python, JS, or JSON, not pseudocode.
-5. **Match existing app patterns** — copy peer artifacts for Report/Page/DocType/Print Format.
-6. **Bench steps** — migrate only for schema JSON; build only for JS/CSS/public; omit if not needed.
-7. **Don't over-build** — a report-only request should not create DocTypes; a bug fix should not add new artifacts.
+### Planning principles (Cursor / Antigravity style)
+1. **Todos, not code** — each item is a clear task with a detailed description and acceptance criteria.
+2. **No assumptions** — if scope, behavior, field names, or UX are unclear from the request or codebase analysis, ask the user in **Questions for User**. Do not guess.
+3. **Ground in analysis** — reference exact file paths and line ranges from the codebase analysis. Quote short excerpts (1–3 lines) only for context, never full replacements.
+4. **Minimal scope** — only tasks required for this request type. No drive-by refactors.
+5. **Exploration is done** — do not add read/inspect/explore tasks.
 
-### Plan scope examples (by request type)
-- **Bug Fix**: 1–3 tasks on the failing path (.py, .js, or hooks.py)
-- **Reports & analytics**: report `.json` + `.py` (+ `.js` for filters) — reference the peer report
-- **DocTypes & data model**: `.json` + controller `.py` + client `.js` + permissions
-- **Forms & desk UI**: client `.js` changes, optional server `.py` if calls needed
-- **Server & business logic**: controller `.py`, whitelisted methods, queries
-- **Documents & output**: Print Format JSON/HTML + any helper `.py`
-- **Integrations**: integration module `.py` + config + optional client wiring
-- **Platform & maintenance**: hooks.py, patches, scheduled jobs
-- **ERPNext-flavored**: custom hooks/overrides around standard ERPNext DocTypes
-
-### Plan Format (EXACT)
+### Plan Format (use these exact section headings)
 
 ---
 
-## Summary
-2-3 sentences: what this plan accomplishes and which files are affected.
+## Overview
+2–4 sentences: goal, approach, and which areas of the app are affected.
 
-## Checklist
+## Scope
+**In scope:** bullet list of what this plan covers
+**Out of scope:** bullet list of what is explicitly NOT included (prevents scope creep)
 
-### Task 1: [Action verb + what changes]
-**File:** `exact/path/to/file.ext`
+## Assumptions
+List assumptions you are making based on the codebase analysis.
+If you have none, write exactly: `None — all requirements verified from codebase analysis.`
+
+## Questions for User
+If ANYTHING is ambiguous, missing, or could be interpreted multiple ways, list numbered questions here.
+Be specific — reference what you found vs what you need.
+If the request is fully clear, write exactly: `None — request is fully clear.`
+
+## Implementation Todos
+
+Each todo is one logical unit of work. Use this structure for every todo:
+
+### TODO 1: [Short action title]
+**Goal:** One sentence outcome.
+**Description:** Detailed instructions for the implementer — what to change, where, and why. Reference file paths and line ranges from the analysis. Describe behavior and patterns to follow (e.g. "match the peer report at …"). Do NOT paste code.
+**Files:** `path/one.ext`, `path/two.ext`
 **Action:** MODIFY | CREATE | DELETE
-**Lines affected:** [start_line]-[end_line] (for MODIFY)
-
-**Context — what currently exists at this location:**
-```
-[Quote 3-5 lines of actual code from the codebase analysis above, with line numbers]
-```
-
-**New code to write:**
-```
-[Complete, production-ready code — NOT pseudocode]
-[Include proper indentation matching the file]
-[Include all necessary imports/dependencies]
-```
-
-**Insertion point:** After line [N] / Replace lines [N]-[M] / New file
-
-**Why:** One sentence.
+**Acceptance criteria:**
+- [ ] Measurable check 1
+- [ ] Measurable check 2
+**Dependencies:** TODO N (or None)
 
 ---
 
-(Repeat for every task)
+(Repeat for every todo — typically 2–8 todos depending on request size)
 
 ## Execution Order
-1. Task N — reason for ordering
-2. Task M — depends on N being done
-...
+Numbered list explaining why todos run in this sequence and any dependencies.
+
+## Bench Commands
+- **migrate:** yes/no — reason (schema JSON changed?)
+- **build:** yes/no — reason (JS/CSS/public assets changed?)
+- **clear-cache:** yes/no — reason
 
 ## Testing Checklist
-- [ ] Implementation matches the user request (scope only — no extra files or features)
-- [ ] .py and .js syntax valid; .json is valid JSON
-- [ ] Server-client wiring correct if the request needs frappe.call / whitelisted APIs
-- [ ] bench migrate / bench build steps listed if schema or assets changed
-- [ ] No unrelated files modified
+- [ ] Request scope satisfied — no extra files or features
+- [ ] Syntax valid (.py, .js, .json as applicable)
+- [ ] Server–client wiring correct if APIs involved
+- [ ] Bench steps listed match actual changes
 
-## Risk Assessment
-- Potential issues and mitigation
+## Risks & Mitigations
+Bullet list of potential issues and how to avoid them.
 
 ---
 
-### CRITICAL WARNINGS
-- **NEVER create a task that just says "read" or "inspect"** — all reading is already done
-- **NEVER write "update as needed" or "add appropriate code"** — write the EXACT code
-- **NEVER assume a field/function exists if it wasn't found in the codebase analysis**
-- **If the user's request requires a server-side API change**, include that task
-- **If new CSS is needed**, include a task for CSS changes
-- **Always include error handling** in new code
-- **When creating new Frappe artifacts** (Reports, DocTypes, Pages): copy a complete JSON structure from an existing artifact of the same type in the codebase analysis. Review checks request scope and blocking issues — not a field-by-field metadata audit.
+### FORBIDDEN in this plan
+- **NO** "New code to write" or code blocks with implementation
+- **NO** pseudocode or partial functions
+- **NO** "update as needed" or "add appropriate logic"
+- **NO** exploration/read-only tasks
+- **NO** guessing field names, API paths, or behavior — ask in Questions for User instead
+
+### When to ask questions (examples)
+- User request mentions a feature but analysis shows multiple valid places to implement it
+- Required field names or DocType names not found in analysis
+- UX behavior not specified (filters, permissions, defaults)
+- Conflict between user request and existing app patterns
 """
     template = get_config_prompt("plan_prompt", default, request_name)
 
@@ -423,48 +454,47 @@ def get_implement_prompt(plan: str, understanding_summary: str, user_message: st
     default = """## ORIGINAL USER REQUEST
 {user_message}
 
-## APPROVED PLAN TO EXECUTE
+## APPROVED PLAN (Todos — implement each one)
 {plan}
+
+The plan contains **todo descriptions only** — no pre-written code. You must read the codebase, follow each TODO's description and acceptance criteria, and write production-ready code yourself.
+
+## CODEBASE CONTEXT FROM EXPLORATION
+{understanding_summary}
 
 ## PRE-LOADED FILE CONTENTS (with line numbers)
 {file_contents}
 
-## IMPLEMENTATION INSTRUCTIONS — FOLLOW EXACTLY
+## IMPLEMENTATION INSTRUCTIONS
 
-### Read order by task type (before each edit)
+Work through every **TODO** in the approved plan, in the stated execution order.
+
+For each TODO:
+1. **Read** the files listed in the todo (use read_file at the exact line ranges mentioned)
+2. **Verify** anchors match the codebase — re-read if line numbers shifted
+3. **Implement** the described change with replace_lines (preferred) or write_file for new files
+4. **Validate** with validate_code on every .py and .js edit
+5. **Confirm** the todo's acceptance criteria before moving to the next
+
+### Read order by task type
 - **Bug fix**: failing file first → trace related .py/.js/hooks.py
 - **DocType**: .json → .py → .js (if all exist)
-- **Report**: .json → .py → .js (copy peer report pattern)
+- **Report**: .json → .py → .js (copy peer report pattern from codebase)
 - **Page**: .json → .py → .js → .html
 - **Hook/API only**: hooks.py and/or target .py
 
-### Workflow for EACH task:
-
-**Step 1: Read target location**
-- `read_file(path, start_line, end_line)` at exact edit location
-- Check imports (lines 1–30) for frappe, json, datetime
-- Read 10+ lines above and below
-
-**Step 2: Anchor Verification**
-- Confirm unique 3-line anchor matches plan line numbers; else `search_code`
-
-**Step 3: Apply edit**
-- `replace_lines` (preferred); match indentation; never edit_file for multi-line
-
-**Step 4: validate_code** on .py/.js — fix SYNTAX_ERROR immediately
-
-**Step 5: read_file** edited region; for cross-file tasks verify fieldnames/method paths match
-
-### CRITICAL RULES:
+### CRITICAL RULES
 - **Read → Anchor → Edit → Validate → Verify** for every change
+- **Implement ALL todos** — don't skip; don't add unplanned files
+- **Match existing app patterns** — copy structure from peer artifacts when creating new ones
 - **NEVER insert code inside JS template literals**
-- **Implement ALL plan tasks** — don't skip; don't add unplanned files
+- **NEVER guess** field names or API paths — read files first
 - List [MODIFIED] and [CREATED] files when done
 
-### If problems:
-- EDIT_FAILED → re-read file, fresh line numbers
-- Bug fix → search_code for error symbol; don't create new artifacts
-- Line numbers shifted → re-read before retry
+### If problems
+- EDIT_FAILED → re-read file, use fresh line numbers
+- Line numbers shifted → search_code or re-read before retry
+- Todo description conflicts with file contents → follow the file, note in output
 """
     template = get_config_prompt("implement_prompt", default, request_name)
 

--- a/ampower_koda/agent/prompts.py
+++ b/ampower_koda/agent/prompts.py
@@ -3,6 +3,8 @@
 
 import frappe
 
+from ampower_koda.agent.errors import log_agent_error
+
 # Mapping internal fieldname -> prompt_key option label
 PROMPT_LABEL_MAP = {
     "system_prompt": "System Prompt",
@@ -29,7 +31,10 @@ def render_prompt_safe(template: str, context: dict, default_template: str) -> s
     try:
         result = template.format_map(SafeDict(context))
     except Exception as e:
-        frappe.log_error(f"Prompt render failed: {e}\nTemplate preview: {template[:200]}", "Prompt Render Error")
+        log_agent_error(
+            "Prompt Render Error",
+            f"{e}\nTemplate preview: {template[:200]}\n{frappe.get_traceback()}",
+        )
         result = template
 
     for key, value in context.items():
@@ -70,18 +75,18 @@ def get_config_prompt(fieldname: str, default_template: str, request_name: str =
             )
 
             if len(overrides) > 1:
-                frappe.log_error(
-                    title="Duplicate Prompt Configuration",
-                    message=f"Multiple prompts found for {request_name}, prompt_key={prompt_label}. Using first (idx asc)."
+                log_agent_error(
+                    "Duplicate Prompt Configuration",
+                    f"Multiple prompts found for {request_name}, prompt_key={prompt_label}. Using first (idx asc).",
                 )
 
             if overrides:
                 return overrides[0]["content"]
 
         except Exception as e:
-            frappe.log_error(
-                title="Prompt Fetch Failed",
-                message=f"request_name={request_name}, fieldname={fieldname}\n{str(e)}"
+            log_agent_error(
+                "Prompt Fetch Failed",
+                f"request_name={request_name}, fieldname={fieldname}\n{e}\n{frappe.get_traceback()}",
             )
 
     return default_template

--- a/ampower_koda/agent/prompts.py
+++ b/ampower_koda/agent/prompts.py
@@ -44,7 +44,7 @@ def get_config_prompt(fieldname: str, default_template: str, request_name: str =
     """
     Return the prompt template for a given fieldname.
     If request_name is provided and the request has a matching prompt override
-    in its AI Agent Prompt Configuration child table, that is returned instead.
+    in its Agent Prompt Configuration child table, that is returned instead.
     If use_default_prompts is enabled on the request, always returns the default.
     """
     prompt_label = PROMPT_LABEL_MAP.get(fieldname, fieldname)
@@ -53,14 +53,14 @@ def get_config_prompt(fieldname: str, default_template: str, request_name: str =
     if request_name:
         try:
             # Fetch parent doc first
-            doc = frappe.get_doc("AI Agent Request", request_name)
+            doc = frappe.get_doc("Agent Request", request_name)
 
             # If "Use Default Prompts" is enabled → skip overrides completely
             if doc.use_default_prompts:
                 return default_template
 
             overrides = frappe.get_all(
-                "AI Agent Prompt Configuration",
+                "Agent Prompt Configuration",
                 filters={
                     "parent": request_name,
                     "prompt_key": ["in", [prompt_label, fieldname]]  
@@ -88,85 +88,102 @@ def get_config_prompt(fieldname: str, default_template: str, request_name: str =
 
 
 def get_system_prompt(app_name: str, request_name: str = None) -> str:
-    default = """You are an expert Frappe Framework developer and senior software architect.
-You write clean, correct, production-ready code. You NEVER guess — you verify everything by reading the actual code first.
+    default = """You are an expert Frappe Framework developer. You work on ALL types of Frappe app tasks:
+- **Bug fixes** — broken validation, APIs, client scripts, hooks, queries
+- **Feature requests** — new DocTypes, Standard Reports, Pages, workflows, integrations
+- **Improvements** — UX, performance, refactors within scope
+
+You write clean, production-ready Frappe code. You NEVER guess — verify by reading actual artifacts first.
 
 ## ABSOLUTE RULES — VIOLATION CAUSES IMMEDIATE FAILURE
-1. NEVER guess file contents — ALWAYS call read_file BEFORE calling any edit tool.
-2. NEVER fabricate code, paths, field names, or function names you have not seen in the codebase.
-3. When any edit returns EDIT_FAILED, read the file again (line numbers may have shifted) and retry.
-4. NEVER assume a file exists — verify with find_files, list_directory, or read_file first.
-5. NEVER repeat a failed tool call with the same arguments — change your approach.
-6. ALWAYS read the FULL surrounding context (at least 20 lines above and below) before making an edit.
-7. NEVER insert code inside a template literal, string, or comment — check the surrounding code structure.
-8. After EVERY edit, call validate_code on the file to ensure no syntax errors were introduced.
-9. After EVERY edit, call read_file on the edited region to verify logic and indentation.
+1. NEVER guess field names, report config, or API paths etc — read_file BEFORE editing.
+2. NEVER fabricate fieldname, method paths, hook keys, or module names not seen in the codebase.
+3. NEVER create a new standard artifact (DocType, Report, Page, Workspace) without reading an existing one of the SAME type in the app.
+4. NEVER guess file contents — ALWAYS read_file BEFORE any edit.
+5. On EDIT_FAILED, re-read the file (line numbers may have shifted).
+6. NEVER assume a file exists — use find_files, list_directory, or read_file.
+7. NEVER repeat a failed tool call with the same arguments.
+8. Read at least 20 lines above and below before any edit.
+9. NEVER insert code inside a JS template literal, Python string, or comment.
+10. After EVERY .py/.js edit: validate_code, then read_file on the edited region.
+11. When client↔server is involved: frappe.call method path must match @frappe.whitelist() location.
 
-## Smart Exploration Strategy
-- Use `find_files()` FIRST to get the complete directory tree
-- Use `get_file_outline(path)` to see class/function signatures (cheap, no content)
-- Use `read_file(path, start_line, end_line)` to read specific sections
-- Use `search_code(pattern)` to find exact references across the codebase
-- For large files (>300 lines): read in chunks using line ranges, don't read the whole file at once
-- For small files (<300 lines): read the full file
+## CORE ENGINEERING PRINCIPLES
+
+### 1. Think Before Coding
+- Identify task type (bug fix / feature / improvement) and artifact (DocType, Report, Page, hook, API, client script).
+- Bug fix: trace the failure path before changing code. Feature: find a similar artifact in the app first.
+- If ambiguous, state interpretation — never silently pick one. NEVER fabricate names or paths.
+
+### 2. Simplicity First
+- Bug fix: smallest change at the root cause. Feature: only files the feature needs.
+- No extra DocTypes, reports, or APIs beyond the request. Follow existing app patterns.
+
+### 3. Surgical Changes
+- Touch only files the task requires. Don't modify unrelated DocTypes when fixing a report or API bug.
+- Match existing style. Remove only imports YOUR change made unused.
+
+### 4. Goal-Driven Execution
+- Define success for THIS task: bug fixed, report runs, page loads, field appears, API returns data.
+- Verify with validate_code, bench migrate/build as needed, request-scoped review — not metadata audits.
+
+## Smart Frappe Exploration (match task type)
+
+**All tasks:** find_files() → map doctype/, report/, page/, public/, patches/ → read hooks.py
+
+**Bug fix:** search_code for error text / function / fieldname → trace UI → frappe.call → Python → DB
+
+**DocType / field change:** read_doctype_schema + .json + .py + .js together
+
+**New Report:** read existing Script Report in app (.json + .py + .js); note ref_doctype, execute()
+
+**New Page / feature:** read similar page (.json, .py, .js, .html); trace data loading
+
+**API / hooks:** search_code for @frappe.whitelist, doc_events, frappe.call
 
 ## Target app: {app_name}
-- App root: {app_name}/ (all tool paths are relative to this root)
-- Frappe app structure:
-  - {app_name}/<module>/doctype/<doctype_name>/ — .json (schema), .py (server), .js (client)
-  - {app_name}/hooks.py — doc_events, scheduler_events, includes
-  - {app_name}/public/ — static JS/CSS assets
-  - {app_name}/api/ or {app_name}/<module>/*.py — whitelisted API endpoints
-  - {app_name}/<module>/page/<page_name>/ — custom pages (.js, .py, .html, .json)
+- App root: {app_name}/ (all tool paths relative to this root)
+- Standard layout:
+  - {app_name}/<module>/doctype/<name>/ — DocType: .json, .py, .js
+  - {app_name}/<module>/report/<name>/ — Script Report: .json, .py, .js
+  - {app_name}/<module>/page/<name>/ — Page: .json, .py, .js, .html
+  - {app_name}/<module>/print_format/<name>/ — Print Format
+  - {app_name}/hooks.py — doc_events, scheduler_events, fixtures, includes
+  - {app_name}/patches/ — data/schema patches
+  - {app_name}/public/ — JS/CSS assets
+  - {app_name}/<module>/*.py — whitelisted APIs, utilities
 
 ## Frappe conventions
-- Python: from frappe.model.document import Document; @frappe.whitelist() for API endpoints
-- Data: frappe.get_doc, frappe.db.get_value, frappe.db.set_value, frappe.db.get_all
-- DocType name in code uses spaces: "Sales Order", not "sales_order"
-- Client JS: frappe.ui.form.on("Sales Order", {{ refresh(frm) {{ ... }} }})
-- Pages: frappe.pages['page-name'] = function(wrapper) {{{{ ... }}}}
-- DocType JSON fields array defines the schema (fieldname, fieldtype, options, label)
-- Child tables are separate DocTypes with istable=1
+- Controllers: Document subclass; @frappe.whitelist() for APIs
+- Data: frappe.get_doc, frappe.get_all, frappe.db.get_value — avoid raw SQL unless app already uses it
+- DocType names in code: spaces ("Sales Order"), not sales_order
+- Forms: frappe.ui.form.on("DocType", {{ refresh(frm) {{ ... }} }})
+- Reports: execute(filters) returns columns/data; report JSON sets ref_doctype, report_type
+- Pages: frappe.pages['page-name'] or desk Page pattern
+- hooks.py: append carefully; no duplicate keys
+- bench migrate after schema JSON; bench build after JS/CSS/public changes
 
-## Frappe JSON File Format — MANDATORY FIELDS
-When creating ANY new .json file for a Frappe artifact, you MUST read an existing file of the same type FIRST and copy its complete structure. Missing required fields will break `bench migrate`.
+## New Frappe artifacts — copy peers
+Before creating DocType, Report, or Page JSON: read an existing artifact of the SAME type in the app and copy its structure. Modify only request-specific fields. At review, only blocking issues are flagged.
 
-**Report JSON** (in <module>/report/<report_name>/<report_name>.json) MUST have:
-- "doctype": "Report", "name": "<Report Name>", "report_name": "<Report Name>"
-- "module": "<Module Name>", "ref_doctype": "<DocType Name>", "report_type": "Script Report"
-- "is_standard": "Yes", "disabled": 0, "docstatus": 0, "idx": 0
-- "owner": "Administrator", "modified_by": "Administrator"
-- "creation": "<timestamp>", "modified": "<timestamp>"
-- "roles": [{{"role": "System Manager"}}]
+## Editing workflow
+1. Read target file(s) — order depends on task (see below)
+2. Anchor verification: unique 3-line block must match before replace_lines
+3. replace_lines (preferred) or insert_lines; validate_code + read_file after
+4. Re-read before second edit
 
-**DocType JSON** (in <module>/doctype/<doctype_name>/<doctype_name>.json) MUST have:
-- "doctype": "DocType", "name": "<DocType Name>", "module": "<Module Name>"
-- "engine": "InnoDB", "fields": [...], "permissions": [...]
-- "creation", "modified", "modified_by", "owner", "naming_rule"
-
-**Page JSON** (in <module>/page/<page_name>/<page_name>.json) MUST have:
-- "doctype": "Page", "name": "<page-name>", "module": "<Module Name>"
-- "page_name": "<page-name>", "standard": "Yes"
-
-**RULE: ALWAYS read an existing artifact of the same type from the codebase BEFORE creating a new one.** Copy its JSON structure exactly, then modify only the fields specific to the new artifact.
-
-## Editing files — CRITICAL WORKFLOW
-1. Read the file (or section) with read_file — note line numbers
-2. Understand the CODE STRUCTURE around the target area:
-   - Is it inside a function? A class method? A template literal? A string?
-   - What is the indentation level?
-   - What is above and below the edit point?
-3. **Anchor Verification (MANDATORY)**: Before making a modification, identify a unique 3-line "anchor" block in the code. If the code at your target line numbers does not match the anchor exactly, use `search_code` to find the new location.
-4. Apply the edit with replace_lines (preferred) or insert_lines.
-5. **Import Safety**: Never assume a utility (like `json`, `datetime`, or `frappe._`) is imported. Check lines 1-30 first.
-6. VERIFY by reading the edited region with read_file.
-7. If the file needs a second edit, RE-READ it first (line numbers have shifted).
+**Read order by task:**
+- Bug fix: failing file first, then trace related files
+- DocType: .json → .py → .js
+- Report: peer report, then new .json → .py → .js
+- Page: peer page, then .json → .py → .js → .html
+- Hook only: hooks.py + affected controller
 
 ## Edit tools:
-- **replace_lines(path, start_line, end_line, new_content)** — PREFERRED. Replaces lines start through end (1-indexed, inclusive).
-- **insert_lines(path, after_line, new_content)** — inserts AFTER the specified 1-indexed line. Use 0 for start of file.
-- **validate_code(path)** — MANDATORY after any edit. Checks for SyntaxErrors.
-- **write_file(path, content)** — ONLY for creating NEW files.
+- **replace_lines(path, start_line, end_line, new_content)** — PREFERRED
+- **insert_lines(path, after_line, new_content)** — insert after line (0 = start)
+- **validate_code(path)** — MANDATORY after .py/.js edits
+- **write_file(path, content)** — NEW files only
 """
     template = get_config_prompt("system_prompt", default, request_name)
     context = {"app_name": app_name}
@@ -183,57 +200,67 @@ def get_understand_prompt(user_message: str, request_type: str, request_name: st
 
 ## YOUR TASK: Comprehensive Codebase Exploration
 
-You must thoroughly explore the codebase to build a complete mental model. The plan's quality depends ENTIRELY on how well you explore. Shallow exploration = bad plan = failed implementation.
+Explore based on the **request type** ({request_type}) and description. Match depth to the task — a bug fix needs the failure path, not every DocType in the app.
 
-### MANDATORY Exploration Steps (DO ALL OF THEM)
+### Exploration by request type
 
-**Step 1 — Map the full codebase structure**
-Call `find_files()` to get the complete directory tree. Study it to identify:
-- All modules, DocTypes, pages, public assets
-- File naming conventions and organization
+**Bug Fix** — isolate the failure path first:
+1. `find_files()` + `read_file("hooks.py")`
+2. `search_code` for error text, function names, or fieldnames from the description
+3. Trace: UI/client `.js` → `frappe.call` → Python `@frappe.whitelist` / controller → DB query
+4. Read failing file(s) fully; read ONE similar working example for pattern
 
-**Step 2 — Read hooks.py**
-Call `read_file("hooks.py")` to understand app configuration, doc_events, includes, routes.
+**Reports & analytics** — use peer reports as templates:
+1. Find a similar Report in the app
+2. Read report `.json`, `.py` (execute), and `.js` (filters) fully
+3. Confirm `ref_doctype`, columns, and filters
 
-**Step 3 — Read ALL relevant files DEEPLY**
-For EVERY file related to the user's request:
+**DocTypes & data model** — schema first:
+1. `read_doctype_schema` for the target DocType
+2. Read `.json` + controller `.py` + client `.js` together
+3. Note child tables, permissions, and naming rules
 
-**For .py files (server logic):**
-- Call `get_file_outline(path)` first to see class/function structure
-- Then call `read_file(path)` to read the FULL file (for files <500 lines)
-- For files >500 lines, read in chunks: `read_file(path, 1, 300)`, then `read_file(path, 301, 600)`, etc.
+**Forms & desk UI** — focus on client files:
+1. Read the DocType client `.js` or page `.js` fully
+2. Trace `frappe.call` methods back to Python
+3. Identify UI patterns in similar forms/pages
 
-**For .js files (client logic):**
-- Call `get_file_outline(path)` first
-- Then READ THE FULL FILE in chunks if large. You MUST understand the complete JS structure.
-  - For Frappe page JS files: understand the page setup, event handlers, data fetching, rendering
-  - Pay special attention to: template literals (backtick strings), jQuery selectors, frappe.call patterns
-- **CRITICAL for JS**: Read the ENTIRE file. Don't stop at the outline. The outline misses inline functions, callbacks, event handlers inside methods, and template literals.
+**Server & business logic** — validate server path:
+1. Read controller `.py`, whitelisted methods, and helper modules
+2. Trace validation hooks and DB queries
+3. Check `hooks.py` if events are involved
 
-**For .json files (DocType schemas):**
-- **CRITICAL**: Read the full file with `read_doctype_schema`. This is the ONLY source of truth for field names, types, and labels. Never guess field names from UI labels or speculative Python code.
+**Documents & output** — templates and formats:
+1. Find peer Print Formats or output templates
+2. Read JSON/HTML/Jinja and any helper `.py` scripts
 
-**For .html files:**
-- Read the full file to understand templates and Jinja patterns
+**Integrations** — external IO:
+1. Read existing integration modules or API clients
+2. Trace auth, request/response handling, and data mapping
 
-**For .css files:**
-- Read the full file if the request involves UI changes
+**Platform & maintenance** — infra inside app:
+1. Read `hooks.py`, `patches.txt`, scheduled jobs, and patch files
+2. Trace migrations or background jobs related to the request
 
-**Step 4 — Search for ALL references**
-Use `search_code(pattern)` for:
-- Every entity mentioned in the user's request (feature names, field names, function names)
-- Related patterns: "def get_", "frappe.call", event handler names
-- **JS-to-Python Bridge**: When you find a `frappe.call({ method: '...' })` in JS, you MUST search for that method string in Python to find the endpoint logic.
+**ERPNext-flavored** — extend standard flows:
+1. Identify the ERPNext DocType and the custom override area
+2. Read custom controllers, hooks, or scripts that touch standard flows
 
-**Step 5 — Trace data flow end-to-end**
-- How does data flow from the UI to the server and back?
-- What API endpoints are called? What do they return?
-- What fields/filters are used in database queries?
+### File-type reading rules
 
-**Step 6 — Study similar existing features**
-- Find existing filters, dropdowns, or similar UI patterns in the codebase
-- Read how they are implemented — what patterns, what libraries, what API calls
-- You will need to follow these EXACT patterns in the plan
+**`.py`** — get_file_outline then read_file (chunks if >500 lines). Controllers, report execute(), whitelisted APIs, patches.
+
+**`.js`** — read FULL file for form scripts, report JS, page JS. Watch template literals, frappe.call, frm handlers.
+
+**`.json`** — DocType: `read_doctype_schema`. Report/Page: read_file on the JSON. Never guess fieldnames.
+
+**`.html` / `.css`** — read if UI/page task.
+
+**`hooks.py`** — always read early for any server-side or event-related task.
+
+### Search patterns
+- `frappe.call`, `@frappe.whitelist`, `doc_events`, fieldnames, function names from the request
+- JS-to-Python: every `frappe.call({{ method: '...' }})` → search method in Python
 
 ### OUTPUT FORMAT
 
@@ -297,13 +324,24 @@ You are writing this plan for an AI agent that will execute it step-by-step. The
 **CRITICAL: Do NOT call any tools. You already have all the codebase information above. Write the plan ONLY.**
 
 ### RULES FOR EVERY TASK IN THE PLAN
-1. **Every task MUST be an actual code change** — No "read file" or "inspect" tasks. The exploration is DONE.
-2. **Reference exact line numbers** — "Add after line 1042" or "Replace lines 150-165 with..."
-3. **Show complete code** — Not pseudocode, not partial code, not "add appropriate code." Show the ACTUAL code.
-4. **Preserve surrounding context** — Show 2-3 lines above and below the change so the agent knows where it goes.
-5. **Respect code structure** — Don't insert code inside template literals, strings, or wrong scope levels.
-6. **Match existing patterns** — Use the same indentation, naming, style as the existing code.
-7. **Handle server + client** — If the feature needs server-side data, plan both the API endpoint AND the client code.
+1. **Every task MUST be an actual code change** — exploration is DONE.
+2. **Scope to the request type** — only the files needed for that category.
+3. **Reference exact line numbers** for MODIFY tasks.
+4. **Show complete code** — actual Python, JS, or JSON, not pseudocode.
+5. **Match existing app patterns** — copy peer artifacts for Report/Page/DocType/Print Format.
+6. **Bench steps** — migrate only for schema JSON; build only for JS/CSS/public; omit if not needed.
+7. **Don't over-build** — a report-only request should not create DocTypes; a bug fix should not add new artifacts.
+
+### Plan scope examples (by request type)
+- **Bug Fix**: 1–3 tasks on the failing path (.py, .js, or hooks.py)
+- **Reports & analytics**: report `.json` + `.py` (+ `.js` for filters) — reference the peer report
+- **DocTypes & data model**: `.json` + controller `.py` + client `.js` + permissions
+- **Forms & desk UI**: client `.js` changes, optional server `.py` if calls needed
+- **Server & business logic**: controller `.py`, whitelisted methods, queries
+- **Documents & output**: Print Format JSON/HTML + any helper `.py`
+- **Integrations**: integration module `.py` + config + optional client wiring
+- **Platform & maintenance**: hooks.py, patches, scheduled jobs
+- **ERPNext-flavored**: custom hooks/overrides around standard ERPNext DocTypes
 
 ### Plan Format (EXACT)
 
@@ -345,10 +383,11 @@ You are writing this plan for an AI agent that will execute it step-by-step. The
 ...
 
 ## Testing Checklist
-- [ ] Specific verification step 1
-- [ ] Specific verification step 2
-- [ ] Existing feature X still works
-- [ ] Edge case Y is handled
+- [ ] Implementation matches the user request (scope only — no extra files or features)
+- [ ] .py and .js syntax valid; .json is valid JSON
+- [ ] Server-client wiring correct if the request needs frappe.call / whitelisted APIs
+- [ ] bench migrate / bench build steps listed if schema or assets changed
+- [ ] No unrelated files modified
 
 ## Risk Assessment
 - Potential issues and mitigation
@@ -362,7 +401,7 @@ You are writing this plan for an AI agent that will execute it step-by-step. The
 - **If the user's request requires a server-side API change**, include that task
 - **If new CSS is needed**, include a task for CSS changes
 - **Always include error handling** in new code
-- **When creating new Frappe artifacts** (Reports, DocTypes, Pages, Print Formats): the plan MUST include ALL required JSON fields. Find an existing artifact of the same type in the codebase analysis, copy its COMPLETE JSON structure, and only change the name/module/content-specific fields. A report JSON with missing `doctype`, `name`, or `module` fields will break `bench migrate`.
+- **When creating new Frappe artifacts** (Reports, DocTypes, Pages): copy a complete JSON structure from an existing artifact of the same type in the codebase analysis. Review checks request scope and blocking issues — not a field-by-field metadata audit.
 """
     template = get_config_prompt("plan_prompt", default, request_name)
 
@@ -387,43 +426,40 @@ def get_implement_prompt(plan: str, understanding_summary: str, user_message: st
 
 ## IMPLEMENTATION INSTRUCTIONS — FOLLOW EXACTLY
 
-### Your workflow for EACH task in the plan:
+### Read order by task type (before each edit)
+- **Bug fix**: failing file first → trace related .py/.js/hooks.py
+- **DocType**: .json → .py → .js (if all exist)
+- **Report**: .json → .py → .js (copy peer report pattern)
+- **Page**: .json → .py → .js → .html
+- **Hook/API only**: hooks.py and/or target .py
 
-**Step 1: Read the target area and check Imports**
-- Call `read_file(path, start_line, end_line)` to see the CURRENT content at the exact location
-- **Import Check**: If your task uses a utility (e.g. `json`, `datetime`, `frappe._`), call `read_file(path, 1, 30)` to verify it is imported. If not, add it as your first sub-task.
-- Read at least 10 lines above and 10 lines below the planned change
+### Workflow for EACH task:
+
+**Step 1: Read target location**
+- `read_file(path, start_line, end_line)` at exact edit location
+- Check imports (lines 1–30) for frappe, json, datetime
+- Read 10+ lines above and below
 
 **Step 2: Anchor Verification**
-- Identify a unique 3-line block in the current code that serves as an "anchor."
-- If the anchor is not at the line numbers specified in the plan, use `search_code` to find the correct new location.
-- DO NOT proceed with `replace_lines` until you have confirmed the exact current line numbers.
+- Confirm unique 3-line anchor matches plan line numbers; else `search_code`
 
-**Step 3: Apply the edit**
-- Use `replace_lines(path, start, end, new_code)` for modifications
-- Match indentation EXACTLY — count the spaces in the surrounding code
-- NEVER use edit_file for multi-line changes
+**Step 3: Apply edit**
+- `replace_lines` (preferred); match indentation; never edit_file for multi-line
 
-Step 4: VALIDATE the edit
-- Call `validate_code(path)` on the modified file
-- If it returns a SYNTAX_ERROR, you MUST fix it immediately before proceeding
+**Step 4: validate_code** on .py/.js — fix SYNTAX_ERROR immediately
 
-Step 5: VERIFY the edit succeeded
-- Call `read_file(path, start_line, end_line)` on the modified area
-- Check: Does the code look correct? Is indentation right? Are brackets balanced?
+**Step 5: read_file** edited region; for cross-file tasks verify fieldnames/method paths match
 
 ### CRITICAL RULES:
-- **Read → Think → Verbatim Anchor Check → Edit → Verify** for EVERY change
-- **NEVER insert code inside a template literal** (backtick string).
-- **Implement ALL tasks** from the plan — don't skip any
-- **After all edits**, list every modified/created file:
-  [MODIFIED] path/to/file.ext
-  [CREATED] path/to/new_file.ext
+- **Read → Anchor → Edit → Validate → Verify** for every change
+- **NEVER insert code inside JS template literals**
+- **Implement ALL plan tasks** — don't skip; don't add unplanned files
+- List [MODIFIED] and [CREATED] files when done
 
-### If you encounter problems:
-- EDIT_FAILED → Re-read the file, get fresh line numbers, try again
-- Can't find the target location → Use search_code to find it
-- Line numbers don't match → The file may have been edited already. Re-read it.
+### If problems:
+- EDIT_FAILED → re-read file, fresh line numbers
+- Bug fix → search_code for error symbol; don't create new artifacts
+- Line numbers shifted → re-read before retry
 """
     template = get_config_prompt("implement_prompt", default, request_name)
 
@@ -447,16 +483,33 @@ def get_review_prompt(edits_made: list[dict], user_message: str, request_name: s
 ## FILES MODIFIED
 {paths_list}
 
-## REVIEW INSTRUCTIONS
+## TESTING INSTRUCTIONS (Frappe)
 
-Read each modified file ONCE with `read_file(path)`. Call `validate_code(path)` to verify zero syntax errors. You are an ADVERSARIAL reviewer. Try to find a reason why the code will fail (NameError, AttributeError, SyntaxError).
+Test whether the changes **satisfy the USER REQUEST above** and still keep existing behavior stable. Stay within request scope — do not audit fields, files, or features the user did not ask for.
 
-For each file check:
-1. **Implicit Dependencies**: Are all used variables (e.g. `json`, `frappe`, `datetime`, `_`) actually imported at the top?
-2. **Path Integrity**: No code inserted inside template literals or strings.
-3. **Syntax**: Brackets balanced, indentation correct (4 spaces for Python).
-4. **Correctness**: Implements the request, event handlers bound, server calls have callbacks.
-5. **Frappe JSON validation**: For every .json file created/modified, verify mandatory fields (`doctype`, `name`, `module`). Missing any = `REVIEW_PASSED=no`.
+Read each modified file with `read_file(path)`. Call `validate_code(path)` on every .py and .js file.
+
+### Generic testing checklist
+1. **Request scope** — Matches what was asked (bug fixed / report added / feature built)? No unrelated files?
+2. **Syntax** — .py/.js pass validate_code; .json is valid JSON.
+3. **Imports** — frappe, json, datetime imported where used.
+4. **Wiring** — frappe.call ↔ @frappe.whitelist if client↔server; report execute() if Script Report; form handlers if DocType UI.
+5. **Consistency** — fieldnames/method paths match across files touched by THIS change only.
+
+### Testing by task type
+- **Bug fix**: original issue addressed; no scope creep.
+- **Report**: report files work together; don't fail for missing DocType fields unless part of request.
+- **DocType**: schema + controller + client consistent if all were in scope.
+- **Page/API/hook**: artifact loads or runs; hook keys not duplicated.
+
+### JSON — scoped only
+- Read actual file content. No field-by-field metadata audits.
+- Fail only blocking issues: invalid JSON, wrong doctype, missing fields required for THIS request.
+- Accept same metadata pattern as peer artifacts in the app.
+
+### Verdict rules
+- `REVIEW_PASSED=yes` — request implemented, syntax valid, no blocking Frappe bug.
+- `REVIEW_PASSED=no` — only real bugs: syntax errors, broken imports, code inside JS template literals, mismatched fieldnames, or JSON that would break migrate. List **at most 5** issues with concrete fixes.
 
 After reading ALL files, give your verdict IMMEDIATELY.
 

--- a/ampower_koda/agent/prompts.py
+++ b/ampower_koda/agent/prompts.py
@@ -11,6 +11,8 @@ PROMPT_LABEL_MAP = {
     "understand_prompt": "Understand Prompt",
     "plan_prompt": "Plan Prompt",
     "implement_prompt": "Implement Prompt",
+    "review_prompt": "Review Prompt",
+    "follow_up_prompt": "Follow-up Prompt",
 }
 
 class SafeDict(dict):
@@ -475,4 +477,100 @@ you changed and why. Do not include code in the summary.
         "file_contents": file_contents
     }
 
+    return render_prompt_safe(template, context, default)
+
+
+def get_follow_up_implement_prompt(
+    follow_up_message: str,
+    original_plan: str,
+    implementation_memory: str,
+    prior_files: str,
+    file_contents: str,
+    request_name: str = None,
+) -> str:
+    """Patch-only prompt for follow-up runs — fix the bug, don't re-implement."""
+    default = """## FOLLOW-UP BUG FIX (PATCH MODE — NOT A RE-IMPLEMENTATION)
+
+The user tested the previous implementation and reported a specific issue below.
+Your job is to **fix only that issue** with minimal, surgical edits.
+
+### USER FOLLOW-UP ISSUE
+{follow_up_message}
+
+### ORIGINAL APPROVED PLAN (for context only — do NOT re-execute from scratch)
+{original_plan}
+
+### WHAT WAS ALREADY BUILT (memory from the last run)
+{implementation_memory}
+
+### FILES CHANGED IN THE PREVIOUS RUN
+{prior_files}
+
+### CURRENT FILE CONTENTS (pre-loaded)
+{file_contents}
+
+## PATCH RULES (CRITICAL)
+1. **Fix the follow-up issue only** — do not rebuild features that already work.
+2. **Do NOT re-implement the full plan** — read the pre-loaded files and patch what is broken.
+3. **Minimal diff** — change only the lines needed; no drive-by refactors.
+4. **Read → edit → validate** — read_file first, then replace_lines/insert_lines/edit_file.
+5. Run validate_code on every changed .py/.js file.
+6. Do NOT create README, notes, .txt markers, or scratch files.
+7. If the bug is in a file not pre-loaded, read that file first — do not guess.
+
+### FINAL STEP
+End with `SUMMARY OF CHANGES:` — 2–5 sentences on what you fixed for this follow-up only.
+"""
+    template = get_config_prompt("follow_up_prompt", default, request_name)
+    context = {
+        "follow_up_message": follow_up_message,
+        "original_plan": original_plan,
+        "implementation_memory": implementation_memory or "(no prior implementation summary recorded)",
+        "prior_files": prior_files,
+        "file_contents": file_contents,
+    }
+    return render_prompt_safe(template, context, default)
+
+
+def get_review_prompt(edits_made: list[dict], user_message: str, request_name: str = None) -> str:
+    """Prompt for the test stage focused on clean code + Frappe standards."""
+    paths = [e.get("path", "") for e in edits_made if e.get("path")]
+    paths_list = "\n".join(f"- {p}" for p in paths) if paths else "(no specific paths recorded)"
+
+    default = """## USER REQUEST
+{user_message_short}
+
+## FILES MODIFIED
+{paths_list}
+
+You are in the TEST STAGE. Validate that the implementation is correct, clean, and
+meets Frappe standards. Keep this review brief and focused.
+
+### Scope & efficiency rules (keep tokens low)
+- ONLY inspect the files listed above.
+- Prefer `read_file(path, start_line, end_line)` with targeted line ranges.
+- Call `validate_code(path)` for each modified .py/.js file.
+- Do NOT explore unrelated files or modules.
+- Limit your output to at most 5 issues.
+
+### Clean code & Frappe standards checklist
+1. **No hallucinations** — fieldnames, methods, DocTypes, and routes match real files.
+2. **Server/client wiring** — frappe.call ↔ @frappe.whitelist() paths match.
+3. **Frappe patterns** — use frappe.db/orm methods; avoid raw SQL unless necessary.
+4. **No debug artifacts** — no print/console.log, no leftover TODOs, no scratch files.
+5. **DocType consistency** — JSON/py/js changes agree on fieldnames & behavior.
+6. **Style** — consistent naming, no dead code, no unused imports.
+
+### Verdict format (REQUIRED)
+- All good: `REVIEW_PASSED=yes`
+- Issues found: `REVIEW_PASSED=no` then list each issue:
+  - File: path — Issue: ... — Fix: ...
+
+After reading the files, output the verdict immediately.
+"""
+    template = get_config_prompt("review_prompt", default, request_name)
+    context = {
+        "user_message_short": user_message[:800] if user_message else "",
+        "paths_list": paths_list,
+    }
     return render_prompt_safe(template, context, default)

--- a/ampower_koda/agent/state.py
+++ b/ampower_koda/agent/state.py
@@ -41,6 +41,17 @@ class AgentState(TypedDict, total=False):
     edits_made: list  # [{path, summary}, ...]
     change_summary: str  # plain-English summary of what the implement phase changed
 
+    # Follow-up patch mode
+    is_follow_up: bool
+    follow_up_message: str
+    prior_changed_paths: list
+    implementation_memory: str
+
+    # Review/Test phase
+    review_passed: bool
+    review_notes: str
+    review_attempts: int
+
     # Pending approvals
     pending_bench_commands: str # JSON-encoded list[str] — always parse with json.loads before use
 

--- a/ampower_koda/agent/state.py
+++ b/ampower_koda/agent/state.py
@@ -39,11 +39,7 @@ class AgentState(TypedDict, total=False):
     # Implementation phase
     implemented_files: list
     edits_made: list  # [{path, summary}, ...]
-
-    # Review phase
-    review_passed: bool
-    review_notes: str
-    review_attempts: int
+    change_summary: str  # plain-English summary of what the implement phase changed
 
     # Pending approvals
     pending_bench_commands: str # JSON-encoded list[str] — always parse with json.loads before use

--- a/ampower_koda/agent/tools.py
+++ b/ampower_koda/agent/tools.py
@@ -6,6 +6,13 @@ import re
 
 import frappe
 
+from ampower_koda.agent.errors import log_agent_error
+
+
+def _tool_error(tool: str, exc: Exception, message: str) -> str:
+    log_agent_error(f"Agent Tool: {tool}", f"{exc}\n{frappe.get_traceback()}")
+    return message
+
 
 def _app_root(app_name: str) -> str:
     """Return the root path of the given Frappe app."""
@@ -41,7 +48,7 @@ def list_directory(app_name: str, path: str) -> str:
             lines.append(prefix + e)
         return "\n".join(lines) if lines else "(empty)"
     except Exception as ex:
-        return f"Error: {ex}"
+        return _tool_error("list_directory", ex, f"Error: {ex}")
 
 
 IGNORE_DIRS = {
@@ -49,8 +56,6 @@ IGNORE_DIRS = {
     ".eggs", "dist", "build",
 }
 
-def _should_ignore_dir(d: str) -> bool:
-    return d in IGNORE_DIRS or d.endswith(".egg-info")
 
 def find_files(app_name: str, pattern: str = "", max_depth: int = 6) -> str:
     """Recursively list the app directory tree. Returns an indented tree view.
@@ -96,7 +101,7 @@ def find_files(app_name: str, pattern: str = "", max_depth: int = 6) -> str:
 
         return "\n".join(lines) if lines else "(empty)"
     except Exception as ex:
-        return f"Error: {ex}"
+        return _tool_error("find_files", ex, f"Error: {ex}")
 
 
 def read_file(app_name: str, path: str, start_line: int = 0, end_line: int = 0) -> str:
@@ -105,7 +110,7 @@ def read_file(app_name: str, path: str, start_line: int = 0, end_line: int = 0) 
     - If start_line and end_line are both > 0, reads only that range (1-indexed, inclusive).
     - Otherwise reads the full file.
 
-    Returns numbered lines (format: '    1 | content') so that line numbers can be used 
+    Returns numbered lines (format: '    1 | content') so that line numbers can be used
     directly with replace_lines / insert_lines.
     """
     try:
@@ -131,7 +136,7 @@ def read_file(app_name: str, path: str, start_line: int = 0, end_line: int = 0) 
         numbered = [f"{i+1:5d} | {line.rstrip()}" for i, line in enumerate(all_lines)]
         return f"[{path}] {total} lines\n" + "\n".join(numbered)
     except Exception as ex:
-        return f"Error: {ex}"
+        return _tool_error("read_file", ex, f"Error: {ex}")
 
 
 def search_code(app_name: str, pattern: str, path: str = "") -> str:
@@ -149,8 +154,8 @@ def search_code(app_name: str, pattern: str, path: str = "") -> str:
         regex = re.compile(pattern, re.MULTILINE | re.IGNORECASE)
         app_root = _app_root(app_name)
         results = []
-        CONTEXT_LINES = 3
-        MAX_RESULTS = 80
+        context_lines = 3
+        max_results = 80
 
         for dirpath, dirnames, filenames in os.walk(root):
             dirnames[:] = [d for d in dirnames if d not in {
@@ -162,27 +167,31 @@ def search_code(app_name: str, pattern: str, path: str = "") -> str:
                     try:
                         with open(full, "r", encoding="utf-8", errors="replace") as f:
                             lines = f.readlines()
-                    except Exception:
+                    except Exception as e:
+                        log_agent_error(
+                            "Agent Tool: search_code read",
+                            f"path={full}\n{e}\n{frappe.get_traceback()}",
+                        )
                         continue
 
                     rel = os.path.relpath(full, app_root)
                     for i, line in enumerate(lines):
                         if regex.search(line):
-                            start = max(0, i - CONTEXT_LINES)
-                            end = min(len(lines), i + CONTEXT_LINES + 1)
+                            start = max(0, i - context_lines)
+                            end = min(len(lines), i + context_lines + 1)
                             context = []
                             for j in range(start, end):
                                 marker = ">>>" if j == i else "   "
                                 context.append(f"  {marker} {j + 1:4d} | {lines[j].rstrip()}")
                             results.append(f"{rel}:{i + 1}\n" + "\n".join(context))
 
-                            if len(results) >= MAX_RESULTS:
-                                results.append(f"\n... (stopped at {MAX_RESULTS} matches)")
+                            if len(results) >= max_results:
+                                results.append(f"\n... (stopped at {max_results} matches)")
                                 return "\n\n".join(results)
 
         return "\n\n".join(results) if results else f"No matches for: {pattern}"
     except Exception as ex:
-        return f"Error: {ex}"
+        return _tool_error("search_code", ex, f"Error: {ex}")
 
 
 def write_file(app_name: str, path: str, content: str) -> str:
@@ -198,7 +207,7 @@ def write_file(app_name: str, path: str, content: str) -> str:
             f.write(content)
         return f"WRITE_OK: Wrote {len(content)} chars to {path}"
     except Exception as ex:
-        return f"WRITE_FAILED: Error: {ex}"
+        return _tool_error("write_file", ex, f"WRITE_FAILED: Error: {ex}")
 
 
 def edit_file(app_name: str, path: str, old_string: str, new_string: str) -> str:
@@ -229,7 +238,7 @@ def edit_file(app_name: str, path: str, old_string: str, new_string: str) -> str
             f.write(content)
         return f"EDIT_OK: Updated {path} successfully."
     except Exception as ex:
-        return f"EDIT_FAILED: Error: {ex}"
+        return _tool_error("edit_file", ex, f"EDIT_FAILED: Error: {ex}")
 
 
 def replace_lines(app_name: str, path: str, start_line: int, end_line: int, new_content: str) -> str:
@@ -282,7 +291,7 @@ def replace_lines(app_name: str, path: str, start_line: int, end_line: int, new_
             f"File now has {len(result)} lines."
         )
     except Exception as ex:
-        return f"EDIT_FAILED: Error: {ex}"
+        return _tool_error("replace_lines", ex, f"EDIT_FAILED: Error: {ex}")
 
 
 def insert_lines(app_name: str, path: str, after_line: int, new_content: str) -> str:
@@ -316,14 +325,11 @@ def insert_lines(app_name: str, path: str, after_line: int, new_content: str) ->
             f"File now has {len(result)} lines."
         )
     except Exception as ex:
-        return f"EDIT_FAILED: Error: {ex}"
+        return _tool_error("insert_lines", ex, f"EDIT_FAILED: Error: {ex}")
 
 
 def get_file_outline(app_name: str, path: str) -> str:
-    """
-    Extracts class and function definitions from a file (.py, .js, .ts).
-    Includes line numbers for quick navigation.
-    """
+    """Extract class and function definitions from a file (.py, .js, .ts)."""
     try:
         full = _resolve_path(app_name, path)
         if not os.path.isfile(full):
@@ -378,14 +384,11 @@ def get_file_outline(app_name: str, path: str) -> str:
 
         return f"[{path}] {total} lines — outline:\n" + "\n".join(outline)
     except Exception as ex:
-        return f"Error: {ex}"
+        return _tool_error("get_file_outline", ex, f"Error: {ex}")
 
 
 def read_doctype_schema(app_name: str, doctype_name: str) -> str:
-    """
-    Reads the JSON schema file for a Frappe DocType. 
-    Useful for identifying fieldnames and properties.
-    """
+    """Read the JSON schema file for a Frappe DocType."""
     try:
         app_root = _app_root(app_name)
         name_lower = doctype_name.replace(" ", "_").lower()
@@ -397,17 +400,11 @@ def read_doctype_schema(app_name: str, doctype_name: str) -> str:
                     return f.read()
         return f"DocType schema not found: {doctype_name}"
     except Exception as ex:
-        return f"Error: {ex}"
+        return _tool_error("read_doctype_schema", ex, f"Error: {ex}")
 
 
 def validate_code(app_name: str, path: str) -> str:
-    """Check for syntax errors in a .py or .js file (path relative to app root).
-
-    - Returns 'VALID' if no syntax errors are found.
-    - Returns detailed error message with line numbers if syntax is invalid.
-    
-    ALWAYS call this after any edit to verify that the file remains functional.
-    """
+    """Check for syntax errors in a .py or .js file (path relative to app root)."""
     try:
         full = _resolve_path(app_name, path)
         if not os.path.isfile(full):
@@ -427,24 +424,25 @@ def validate_code(app_name: str, path: str) -> str:
                     f"{e.msg}\nLine content: {e.text.strip() if e.text else 'N/A'}"
                 )
             except Exception as e:
+                log_agent_error(
+                    "Agent Tool: validate_code python",
+                    f"path={path}\n{e}\n{frappe.get_traceback()}",
+                )
                 return f"VALIDATION_ERROR: {e}"
 
         elif path.endswith(".js"):
-            # Use node --check for reliable JS syntax validation in Linux
             import subprocess
             try:
                 result = subprocess.run(
                     ["node", "--check", full],
                     capture_output=True,
                     text=True,
-                    timeout=5
+                    timeout=5,
                 )
                 if result.returncode == 0:
                     return f"VALID: {path} has no syntax errors."
-                else:
-                    return f"SYNTAX_ERROR in {path}:\n{result.stderr.strip() or result.stdout.strip()}"
+                return f"SYNTAX_ERROR in {path}:\n{result.stderr.strip() or result.stdout.strip()}"
             except FileNotFoundError:
-                # Basic bracket check if node is missing
                 stack = []
                 for i, char in enumerate(content):
                     if char in "({[":
@@ -460,8 +458,12 @@ def validate_code(app_name: str, path: str) -> str:
                     return f"SYNTAX_ERROR in {path}: Unclosed {char} starting at char {i}"
                 return f"VALID: {path} (basic check: brackets balanced)"
             except Exception as e:
+                log_agent_error(
+                    "Agent Tool: validate_code javascript",
+                    f"path={path}\n{e}\n{frappe.get_traceback()}",
+                )
                 return f"VALIDATION_ERROR: {e}"
 
         return f"SKIP: Validation not supported for this file type: {path}"
     except Exception as ex:
-        return f"VALIDATION_FAILED: Error: {ex}"
+        return _tool_error("validate_code", ex, f"VALIDATION_FAILED: Error: {ex}")

--- a/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.js
+++ b/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.js
@@ -1,8 +1,0 @@
-// Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-// For license information, please see license.txt
-
-// frappe.ui.form.on("Agent Prompt Configuration", {
-// 	refresh(frm) {
-
-// 	},
-// });

--- a/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.js
+++ b/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("AI Agent Prompt Configuration", {
+// frappe.ui.form.on("Agent Prompt Configuration", {
 // 	refresh(frm) {
 
 // 	},

--- a/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.json
+++ b/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.json
@@ -13,7 +13,7 @@
             "fieldtype": "Select",
             "in_list_view": 1,
             "label": "Prompt Type",
-            "options": "System Prompt\nUnderstand Prompt\nPlan Prompt\nImplement Prompt\nReview Prompt",
+            "options": "System Prompt\nUnderstand Prompt\nPlan Prompt\nImplement Prompt\nReview Prompt\nFollow-up Prompt",
             "reqd": 1,
             "description": "Each prompt type should be added only once."
         },

--- a/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.json
+++ b/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.json
@@ -27,6 +27,6 @@
     ],
     "istable": 1,
     "module": "Ampower Koda",
-    "name": "AI Agent Prompt Configuration",
+    "name": "Agent Prompt Configuration",
     "owner": "Administrator"
 }

--- a/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.py
+++ b/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.py
@@ -1,9 +1,12 @@
+# Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
+# For license information, please see license.txt
+
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class AgentPromptConfiguration(Document):
-
     def validate(self):
         existing = frappe.get_all(
             "Agent Prompt Configuration",
@@ -11,11 +14,11 @@ class AgentPromptConfiguration(Document):
                 "parent": self.parent,
                 "parenttype": self.parenttype,
                 "prompt_key": self.prompt_key,
-                "name": ["!=", self.name]
+                "name": ["!=", self.name],
             },
-            limit=1
+            limit=1,
         )
         if existing:
             frappe.throw(
-                f"Prompt Type '{self.prompt_key}' already exists for this document."
+                _("Prompt Type '{0}' already exists for this document.").format(self.prompt_key)
             )

--- a/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.py
+++ b/ampower_koda/ampower_koda/doctype/agent_prompt_configuration/agent_prompt_configuration.py
@@ -2,11 +2,11 @@ import frappe
 from frappe.model.document import Document
 
 
-class AIAgentPromptConfiguration(Document):
+class AgentPromptConfiguration(Document):
 
     def validate(self):
         existing = frappe.get_all(
-            "AI Agent Prompt Configuration",
+            "Agent Prompt Configuration",
             filters={
                 "parent": self.parent,
                 "parenttype": self.parenttype,

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
@@ -176,6 +176,26 @@ function render_status_dashboard(frm) {
         }
     }
 
+    var plan_info_html = '';
+    if (status === 'Awaiting Approval' && (frm.doc.agent_plan || '').trim()) {
+        if (plan_has_open_questions(frm.doc.agent_plan)) {
+            plan_info_html = '<div class="agent-push-info" style="border-left:3px solid var(--orange-500,#f97316);">'
+                + '<strong>Open questions — approval blocked</strong>'
+                + '<p style="margin:6px 0 0;font-size:12px;color:var(--text-muted);">'
+                + 'This plan lists questions under <b>Questions for User</b>. '
+                + 'Answer them in the request description, edit the plan, or set that section to '
+                + '<code>None — request is fully clear.</code> before approving.</p>'
+                + '</div>';
+        } else {
+            plan_info_html = '<div class="agent-push-info">'
+                + '<strong>Review the plan todos</strong>'
+                + '<p style="margin:6px 0 0;font-size:12px;color:var(--text-muted);">'
+                + 'The plan describes <b>what</b> to build — not source code. '
+                + 'Edit todos if needed, then click <b>Approve Plan</b> to start implementation.</p>'
+                + '</div>';
+        }
+    }
+
     var push_info_html = '';
     if (status === 'Awaiting Push Approval') {
         var branch = frm.doc.branch_name || '(auto-generated)';
@@ -209,6 +229,7 @@ function render_status_dashboard(frm) {
         + '<div class="agent-steps-track">' + steps_html + '</div>'
         + pr_html
         + bench_info_html
+        + plan_info_html
         + push_info_html
         + error_html
         + '</div>';
@@ -634,9 +655,32 @@ function execute_existing_plan(frm) {
     );
 }
 
+function plan_has_open_questions(plan) {
+    if (!plan || !plan.trim()) return false;
+    var match = plan.match(/## Questions for User\s*\n([\s\S]*?)(?=\n## |\s*$)/i);
+    if (!match) return false;
+    var body = (match[1] || '').trim();
+    if (!body) return false;
+    var lowered = body.toLowerCase();
+    if (lowered.indexOf('none — request is fully clear') !== -1) return false;
+    if (lowered.indexOf('none - request is fully clear') !== -1) return false;
+    if (lowered.indexOf('no open questions') !== -1) return false;
+    if (lowered.indexOf('none') === 0 && body.split(/\s+/).length <= 6) return false;
+    return true;
+}
+
 function approve_plan(frm) {
+    var plan = frm.doc.agent_plan || '';
+    if (plan_has_open_questions(plan)) {
+        frappe.msgprint({
+            title: __('Open Questions'),
+            message: __('This plan has unanswered questions. Edit the plan or update the request before approving.'),
+            indicator: 'orange'
+        });
+        return;
+    }
     frappe.confirm(
-        __('Approve this plan and start execution?<br><br>The agent will implement the changes, run bench commands, and create a Pull Request.'),
+        __('Approve this plan and start implementation?<br><br>The agent will execute each todo, run bench commands, and prepare changes for push.'),
         function () {
             var edited_plan = frm.doc.agent_plan || '';
             frappe.call({

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
@@ -41,7 +41,7 @@ var REQUEST_TYPE_HELP = {
 
 var STATUS_FLOW = [
     'Queued', 'Understanding', 'Planning', 'Awaiting Approval',
-    'Implementing', 'Awaiting Bench Approval', 'Building',
+    'Implementing', 'Reviewing', 'Awaiting Bench Approval', 'Building',
     'Awaiting Push Approval', 'Pushing', 'Completed'
 ];
 
@@ -51,7 +51,6 @@ var STATUS_META = {
     'Planning': { color: 'blue', label: 'Creating Plan' },
     'Awaiting Approval': { color: 'orange', label: 'Review Plan' },
     'Implementing': { color: 'yellow', label: 'Implementing Changes' },
-    // 'Reviewing' is legacy — no longer produced, kept so historical records still render.
     'Reviewing': { color: 'yellow', label: 'Testing Changes' },
     'Awaiting Bench Approval': { color: 'orange', label: 'Approve Bench Commands' },
     'Building': { color: 'purple', label: 'Running Bench Commands' },
@@ -124,6 +123,7 @@ function render_status_dashboard(frm) {
         { key: 'Planning', short: 'Plan' },
         { key: 'Awaiting Approval', short: 'Review' },
         { key: 'Implementing', short: 'Build' },
+        { key: 'Reviewing', short: 'Test' },
         { key: 'Awaiting Bench Approval', short: 'Bench' },
         { key: 'Awaiting Push Approval', short: 'Push' },
         { key: 'Completed', short: 'Done' }
@@ -576,7 +576,7 @@ function open_follow_up_dialog(frm) {
                 callback: function (r) {
                     if (r.message && r.message.status === 'ok') {
                         frappe.show_alert({
-                            message: __('Follow-up submitted. Agent started targeted fix on same branch.'),
+                            message: __('Follow-up patch started on same branch (plan preserved).'),
                             indicator: 'blue'
                         });
                         dialog.hide();

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
@@ -1,21 +1,23 @@
 // Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-// AI Agent Request — client script
+// Agent Request: client script
 
 var PROVIDER_MODELS = {
     'OpenAI': [
-        { value: 'gpt-4o-mini', label: 'GPT-4o Mini — fast, cost-effective' },
-        { value: 'gpt-4o', label: 'GPT-4o — best overall' },
-        { value: 'gpt-5-mini', label: 'GPT-5 Mini — next-gen, efficient' },
-        { value: 'o3-mini', label: 'o3-mini — reasoning model' }
+        { value: 'gpt-4o-mini', label: 'GPT-4o Mini: fast, cost-effective' },
+        { value: 'gpt-5-mini', label: 'GPT-5 Mini: next-gen, efficient' },
+        { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini: compact coding' },
+        { value: 'gpt-5-codex', label: 'GPT-5 Codex: coding model' },
+        { value: 'gpt-5.1-codex', label: 'GPT-5.1 Codex: coding model' },
+        { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex: latest coding model' }
     ],
     'Gemini': [
-        { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash — fast, multimodal' },
-        { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro — most capable' }
+        { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash: fast, multimodal' },
+        { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro: most capable' }
     ],
     'Claude': [
-        { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4 — balanced' },
-        { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet — proven' },
-        { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku — fast, light' }
+        { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4: balanced' },
+        { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet: proven' },
+        { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku: fast, light' }
     ]
 };
 
@@ -23,6 +25,18 @@ var DEFAULT_MODELS = {
     'OpenAI': 'gpt-4o-mini',
     'Gemini': 'gemini-2.0-flash',
     'Claude': 'claude-sonnet-4-20250514'
+};
+
+var REQUEST_TYPE_HELP = {
+    'Bug Fix': '<b>Highlights:</b> Fix a specific failure (validation error, broken API, JS error, wrong query).',
+    'Reports & analytics': '<b>Highlights:</b> Create or modify Script Reports, filters, columns, or analytics.',
+    'DocTypes & data model': '<b>Highlights:</b> Create/modify DocTypes, fields, child tables, permissions, naming rules.',
+    'Forms & desk UI': '<b>Highlights:</b> Client scripts, buttons, list view tweaks, field visibility, desk UX changes.',
+    'Server & business logic': '<b>Highlights:</b> Validation logic, controller changes, whitelisted APIs, queries.',
+    'Documents & output': '<b>Highlights:</b> Print Formats, PDF templates, document output formatting.',
+    'Integrations': '<b>Highlights:</b> External APIs, webhooks, sync, connectors, third-party services.',
+    'Platform & maintenance': '<b>Highlights:</b> Patches, hooks, scheduler tasks, performance or cleanup work.',
+    'ERPNext-flavored': '<b>Highlights:</b> ERPNext flows (Sales, Stock, Accounts) in your custom app.'
 };
 
 var STATUS_FLOW = [
@@ -37,7 +51,7 @@ var STATUS_META = {
     'Planning': { color: 'blue', label: 'Creating Plan' },
     'Awaiting Approval': { color: 'orange', label: 'Review Plan' },
     'Implementing': { color: 'yellow', label: 'Implementing Changes' },
-    'Reviewing': { color: 'yellow', label: 'Reviewing Code' },
+    'Reviewing': { color: 'yellow', label: 'Testing Changes' },
     'Awaiting Bench Approval': { color: 'orange', label: 'Approve Bench Commands' },
     'Building': { color: 'purple', label: 'Running Bench Commands' },
     'Awaiting Push Approval': { color: 'orange', label: 'Approve Push to GitHub' },
@@ -47,7 +61,7 @@ var STATUS_META = {
     'Cancelled': { color: 'grey', label: 'Cancelled' }
 };
 
-frappe.ui.form.on('AI Agent Request', {
+frappe.ui.form.on('Agent Request', {
     refresh: function (frm) {
         render_status_dashboard(frm);
         setup_action_buttons(frm);
@@ -55,8 +69,13 @@ frappe.ui.form.on('AI Agent Request', {
         setup_status_polling(frm);
         setup_live_log_panel(frm);
         set_model_options_for_provider(frm);
+        update_request_type_help(frm);
         toggle_config_readonly(frm);
         style_form(frm);
+    },
+
+    request_type: function (frm) {
+        update_request_type_help(frm);
     },
 
     ai_provider: function (frm) {
@@ -76,11 +95,12 @@ frappe.ui.form.on('AI Agent Request', {
             load_user_defaults(frm);
             set_model_options_for_provider(frm);
         }
+        update_request_type_help(frm);
     }
 });
 
 // ---------------------------------------------------------------------------
-// Status Dashboard — visual progress indicator
+// Status Dashboard: visual progress indicator
 // ---------------------------------------------------------------------------
 
 function render_status_dashboard(frm) {
@@ -103,7 +123,7 @@ function render_status_dashboard(frm) {
         { key: 'Planning', short: 'Plan' },
         { key: 'Awaiting Approval', short: 'Review' },
         { key: 'Implementing', short: 'Build' },
-        { key: 'Reviewing', short: 'Verify' },
+        { key: 'Reviewing', short: 'Test' },
         { key: 'Awaiting Bench Approval', short: 'Bench' },
         { key: 'Awaiting Push Approval', short: 'Push' },
         { key: 'Completed', short: 'Done' }
@@ -362,7 +382,7 @@ function style_form(frm) {
 }
 
 // ---------------------------------------------------------------------------
-// Model dropdown — filter options by selected provider
+// Model dropdown: filter options by selected provider
 // ---------------------------------------------------------------------------
 
 function set_model_options_for_provider(frm) {
@@ -380,9 +400,16 @@ function set_model_options_for_provider(frm) {
     }
 
     var desc = entries.map(function (m) {
-        return '<b>' + m.value + '</b> — ' + m.label.split(' — ')[1];
+        return '<b>' + m.value + '</b>: ' + m.label.split(': ')[1];
     }).join(' &nbsp;|&nbsp; ');
     frm.set_df_property('ai_model', 'description', desc);
+}
+
+function update_request_type_help(frm) {
+    var value = frm.doc.request_type || '';
+    var text = REQUEST_TYPE_HELP[value] || '<b>Highlights:</b> Select a request type to see what the agent will focus on.';
+    frm.set_df_property('request_type', 'description', text);
+    frm.refresh_field('request_type');
 }
 
 // ---------------------------------------------------------------------------
@@ -493,6 +520,62 @@ function setup_action_buttons(frm) {
             cancel_request(frm);
         }, __('Actions'));
     }
+
+    var followup_allowed = ['Queued', 'Completed', 'Failed', 'Cancelled', 'Awaiting Approval', 'Awaiting Push Approval'].indexOf(status) !== -1;
+    if (followup_allowed && !frm.is_new()) {
+        frm.add_custom_button(__('Submit Follow-up Fix'), function () {
+            open_follow_up_dialog(frm);
+        }, __('Actions'));
+    }
+
+    if ((frm.doc.branch_name || frm.doc.patch_diff) && !frm.is_new()) {
+        frm.add_custom_button(__('Open IDE'), function () {
+            frappe.set_route('agent-diff-viewer', frm.doc.name);
+        }, __('Actions'));
+    }
+}
+
+function open_follow_up_dialog(frm) {
+    var dialog = new frappe.ui.Dialog({
+        title: __('Submit Follow-up Fix'),
+        fields: [
+            {
+                fieldname: 'follow_up_message',
+                fieldtype: 'Small Text',
+                label: __('What broke after testing?'),
+                reqd: 1,
+                description: __('Describe the error/regression observed after the previous run. This will be appended to the request context.'),
+            }
+        ],
+        primary_action_label: __('Start Follow-up Run'),
+        primary_action: function (values) {
+            var msg = (values.follow_up_message || '').trim();
+            if (!msg) {
+                frappe.msgprint(__('Please enter follow-up details.'));
+                return;
+            }
+            frappe.call({
+                method: 'ampower_koda.agent.api.submit_follow_up',
+                args: {
+                    request_name: frm.doc.name,
+                    follow_up_message: msg
+                },
+                freeze: true,
+                freeze_message: __('Submitting follow-up and starting surgical fix on same branch...'),
+                callback: function (r) {
+                    if (r.message && r.message.status === 'ok') {
+                        frappe.show_alert({
+                            message: __('Follow-up submitted. Agent started targeted fix on same branch.'),
+                            indicator: 'blue'
+                        });
+                        dialog.hide();
+                        frm.reload_doc();
+                    }
+                }
+            });
+        }
+    });
+    dialog.show();
 }
 
 function start_agent(frm) {
@@ -505,7 +588,7 @@ function start_agent(frm) {
             callback: function (r) {
                 if (r.message && r.message.status === 'ok') {
                     frappe.show_alert({
-                        message: __('Agent started — exploring codebase...'),
+                        message: __('Agent started: exploring codebase...'),
                         indicator: 'blue'
                     });
                     frm.reload_doc();
@@ -523,7 +606,7 @@ function start_agent(frm) {
 
 function execute_existing_plan(frm) {
     frappe.confirm(
-        __('Skip exploration & planning — execute the existing plan directly?<br><br>The agent will implement the plan, run bench commands, and ask for push approval.'),
+        __('Skip exploration & planning: execute the existing plan directly?<br><br>The agent will implement the plan, run bench commands, and ask for push approval.'),
         function () {
             function do_execute() {
                 frappe.call({
@@ -534,7 +617,7 @@ function execute_existing_plan(frm) {
                     callback: function (r) {
                         if (r.message && r.message.status === 'ok') {
                             frappe.show_alert({
-                                message: __('Executing existing plan — implementation in progress...'),
+                                message: __('Executing existing plan: implementation in progress...'),
                                 indicator: 'blue'
                             });
                             frm.reload_doc();
@@ -567,7 +650,7 @@ function approve_plan(frm) {
                 callback: function (r) {
                     if (r.message && r.message.status === 'ok') {
                         frappe.show_alert({
-                            message: __('Plan approved — execution in progress...'),
+                            message: __('Plan approved: execution in progress...'),
                             indicator: 'green'
                         });
                         frm.reload_doc();
@@ -641,7 +724,7 @@ function approve_bench(frm) {
                 callback: function (r) {
                     if (r.message && r.message.status === 'ok') {
                         frappe.show_alert({
-                            message: __('Bench commands approved — running...'),
+                            message: __('Bench commands approved: running...'),
                             indicator: 'blue'
                         });
                         frm.reload_doc();
@@ -1020,7 +1103,7 @@ function append_log_entry(frm, data) {
 }
 
 // ---------------------------------------------------------------------------
-// User defaults — remember last-used configuration across requests
+// User defaults: remember last-used configuration across requests
 // ---------------------------------------------------------------------------
 
 function save_user_defaults(frm) {
@@ -1036,7 +1119,7 @@ function save_user_defaults(frm) {
         frappe.call({
             method: 'frappe.model.utils.user_settings.save',
             args: {
-                doctype: 'AI Agent Request',
+                doctype: 'Agent Request',
                 user_settings: JSON.stringify(vals)
             },
             async: true
@@ -1047,7 +1130,10 @@ function save_user_defaults(frm) {
 function load_user_defaults(frm) {
     var stored = {};
     try {
-        var raw = frappe.get_user_settings('AI Agent Request');
+        var raw = frappe.get_user_settings('Agent Request');
+        if (!raw || !Object.keys(raw).length) {
+            raw = frappe.get_user_settings('AI Agent Request') || {};
+        }
         if (raw && typeof raw === 'object') stored = raw;
     } catch (e) { /* no saved settings */ }
 

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
@@ -529,8 +529,8 @@ function setup_action_buttons(frm) {
     }
 
     if ((frm.doc.branch_name || frm.doc.patch_diff) && !frm.is_new()) {
-        frm.add_custom_button(__('Open IDE'), function () {
-            frappe.set_route('agent-diff-viewer', frm.doc.name);
+        frm.add_custom_button(__('Open Koda IDE'), function () {
+            frappe.set_route('koda-ide', frm.doc.name);
         }, __('Actions'));
     }
 }
@@ -821,23 +821,11 @@ function checkout_base_branch(frm) {
 }
 
 function show_post_checkout_bench_dialog(frm) {
-    var app = frm.doc.target_app_name || '';
-    var site = frm.doc.site_name || '';
-    var default_cmds = [];
-    if (app) {
-        default_cmds = [
-            'bench --site ' + (site || '{site}') + ' migrate',
-            'bench build --app ' + app,
-            'bench --site ' + (site || '{site}') + ' clear-cache',
-            'supervisorctl restart all'
-        ];
-    }
-
     frappe.call({
         method: 'ampower_koda.agent.api.get_default_bench_commands',
         args: { request_name: frm.doc.name },
         callback: function (r) {
-            var cmds = (r.message && r.message.commands) ? r.message.commands : default_cmds;
+            var cmds = (r.message && r.message.commands) || [];
             if (!cmds.length) return;
 
             var rows_html = cmds.map(function (c, i) {

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.js
@@ -41,7 +41,7 @@ var REQUEST_TYPE_HELP = {
 
 var STATUS_FLOW = [
     'Queued', 'Understanding', 'Planning', 'Awaiting Approval',
-    'Implementing', 'Reviewing', 'Awaiting Bench Approval', 'Building',
+    'Implementing', 'Awaiting Bench Approval', 'Building',
     'Awaiting Push Approval', 'Pushing', 'Completed'
 ];
 
@@ -51,6 +51,7 @@ var STATUS_META = {
     'Planning': { color: 'blue', label: 'Creating Plan' },
     'Awaiting Approval': { color: 'orange', label: 'Review Plan' },
     'Implementing': { color: 'yellow', label: 'Implementing Changes' },
+    // 'Reviewing' is legacy — no longer produced, kept so historical records still render.
     'Reviewing': { color: 'yellow', label: 'Testing Changes' },
     'Awaiting Bench Approval': { color: 'orange', label: 'Approve Bench Commands' },
     'Building': { color: 'purple', label: 'Running Bench Commands' },
@@ -123,7 +124,6 @@ function render_status_dashboard(frm) {
         { key: 'Planning', short: 'Plan' },
         { key: 'Awaiting Approval', short: 'Review' },
         { key: 'Implementing', short: 'Build' },
-        { key: 'Reviewing', short: 'Test' },
         { key: 'Awaiting Bench Approval', short: 'Bench' },
         { key: 'Awaiting Push Approval', short: 'Push' },
         { key: 'Completed', short: 'Done' }
@@ -178,22 +178,12 @@ function render_status_dashboard(frm) {
 
     var plan_info_html = '';
     if (status === 'Awaiting Approval' && (frm.doc.agent_plan || '').trim()) {
-        if (plan_has_open_questions(frm.doc.agent_plan)) {
-            plan_info_html = '<div class="agent-push-info" style="border-left:3px solid var(--orange-500,#f97316);">'
-                + '<strong>Open questions — approval blocked</strong>'
-                + '<p style="margin:6px 0 0;font-size:12px;color:var(--text-muted);">'
-                + 'This plan lists questions under <b>Questions for User</b>. '
-                + 'Answer them in the request description, edit the plan, or set that section to '
-                + '<code>None — request is fully clear.</code> before approving.</p>'
-                + '</div>';
-        } else {
-            plan_info_html = '<div class="agent-push-info">'
-                + '<strong>Review the plan todos</strong>'
-                + '<p style="margin:6px 0 0;font-size:12px;color:var(--text-muted);">'
-                + 'The plan describes <b>what</b> to build — not source code. '
-                + 'Edit todos if needed, then click <b>Approve Plan</b> to start implementation.</p>'
-                + '</div>';
-        }
+        plan_info_html = '<div class="agent-push-info">'
+            + '<strong>Review the plan todos</strong>'
+            + '<p style="margin:6px 0 0;font-size:12px;color:var(--text-muted);">'
+            + 'The plan describes <b>what</b> to build — not source code. '
+            + 'Edit todos if needed, then click <b>Approve Plan</b> to start implementation.</p>'
+            + '</div>';
     }
 
     var push_info_html = '';
@@ -655,30 +645,7 @@ function execute_existing_plan(frm) {
     );
 }
 
-function plan_has_open_questions(plan) {
-    if (!plan || !plan.trim()) return false;
-    var match = plan.match(/## Questions for User\s*\n([\s\S]*?)(?=\n## |\s*$)/i);
-    if (!match) return false;
-    var body = (match[1] || '').trim();
-    if (!body) return false;
-    var lowered = body.toLowerCase();
-    if (lowered.indexOf('none — request is fully clear') !== -1) return false;
-    if (lowered.indexOf('none - request is fully clear') !== -1) return false;
-    if (lowered.indexOf('no open questions') !== -1) return false;
-    if (lowered.indexOf('none') === 0 && body.split(/\s+/).length <= 6) return false;
-    return true;
-}
-
 function approve_plan(frm) {
-    var plan = frm.doc.agent_plan || '';
-    if (plan_has_open_questions(plan)) {
-        frappe.msgprint({
-            title: __('Open Questions'),
-            message: __('This plan has unanswered questions. Edit the plan or update the request before approving.'),
-            indicator: 'orange'
-        });
-        return;
-    }
     frappe.confirm(
         __('Approve this plan and start implementation?<br><br>The agent will execute each todo, run bench commands, and prepare changes for push.'),
         function () {

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
@@ -31,6 +31,8 @@
   "column_break_result",
   "branch_name",
   "pr_number",
+  "changes_summary_section",
+  "change_summary",
   "plan_section",
   "agent_plan",
   "diff_section",
@@ -212,6 +214,18 @@
    "fieldname": "pr_number",
    "fieldtype": "Int",
    "label": "PR Number",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.change_summary",
+   "fieldname": "changes_summary_section",
+   "fieldtype": "Section Break",
+   "label": "Summary of Changes"
+  },
+  {
+   "fieldname": "change_summary",
+   "fieldtype": "Long Text",
+   "label": "Summary of Changes",
    "read_only": 1
   },
   {

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
@@ -1,358 +1,366 @@
 {
-    "actions": [],
-    "autoname": "format:AGENT-{####}",
-    "creation": "2026-03-05 12:00:00.000000",
-    "doctype": "DocType",
-    "engine": "InnoDB",
-    "field_order": [
-        "status_dashboard_html",
-        "request_section",
-        "request_title",
-        "column_break_req1",
-        "request_type",
-        "status",
-        "description_section",
-        "user_message",
-        "model_section",
-        "ai_provider",
-        "column_break_model",
-        "ai_model",
-        "config_section",
-        "target_app_name",
-        "github_repo_url",
-        "github_token",
-        "column_break_config",
-        "base_branch",
-        "branch_prefix",
-        "git_user_name",
-        "git_user_email",
-        "result_section",
-        "pr_url",
-        "column_break_result",
-        "branch_name",
-        "pr_number",
-        "plan_section",
-        "agent_plan",
-        "diff_section",
-        "patch_diff",
-        "logs_section",
-        "stage_log",
-        "bench_log",
-        "error_log",
-        "debug_section",
-        "pending_bench_commands",
-        "conversation_log",
-        "files_changed",
-        "tokens_used",
-        "cost_estimate",
-        "prompts_tab",
-        "use_default_prompts",
-        "prompts_section",
-        "prompts"
-    ],
-    "fields": [
-        {
-            "fieldname": "status_dashboard_html",
-            "fieldtype": "HTML",
-            "label": "Status Dashboard"
-        },
-        {
-            "fieldname": "request_section",
-            "fieldtype": "Section Break",
-            "label": "Request"
-        },
-        {
-            "fieldname": "request_title",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Title",
-            "reqd": 1
-        },
-        {
-            "fieldname": "column_break_req1",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "request_type",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Type",
-            "options": "Bug Fix\nReports & analytics\nDocTypes & data model\nForms & desk UI\nServer & business logic\nDocuments & output\nIntegrations\nPlatform & maintenance\nERPNext-flavored",
-            "reqd": 1
-        },
-        {
-            "default": "Queued",
-            "fieldname": "status",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Status",
-            "options": "Queued\nUnderstanding\nPlanning\nAwaiting Approval\nImplementing\nReviewing\nAwaiting Bench Approval\nBuilding\nAwaiting Push Approval\nPushing\nCompleted\nFailed\nCancelled",
-            "read_only": 1,
-            "hidden": 1
-        },
-        {
-            "fieldname": "description_section",
-            "fieldtype": "Section Break",
-            "label": "Description"
-        },
-        {
-            "fieldname": "user_message",
-            "fieldtype": "Text Editor",
-            "label": "What do you need?",
-            "reqd": 1,
-            "description": "Describe the bug, feature, or improvement in detail. The more context you provide, the better the result."
-        },
-        {
-            "fieldname": "model_section",
-            "fieldtype": "Section Break",
-            "label": "AI Model"
-        },
-        {
-            "fieldname": "ai_provider",
-            "fieldtype": "Select",
-            "label": "Provider",
-            "options": "OpenAI\nGemini\nClaude",
-            "default": "OpenAI",
-            "reqd": 1
-        },
-        {
-            "fieldname": "column_break_model",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "ai_model",
-            "fieldtype": "Select",
-            "label": "Model",
-            "default": "gpt-4o-mini",
-            "reqd": 1,
-            "options": "gpt-4o-mini\ngpt-5-mini\ngpt-5.1-codex-mini\ngpt-5-codex\ngpt-5.1-codex\ngpt-5.2-codex\ngemini-2.0-flash\ngemini-2.5-pro\nclaude-sonnet-4-20250514\nclaude-3-5-sonnet-20241022\nclaude-3-5-haiku-20241022"
-        },
-        {
-            "fieldname": "config_section",
-            "fieldtype": "Section Break",
-            "label": "Repository & Git Configuration",
-            "collapsible": 1,
-            "collapsible_depends_on": "eval:!doc.__islocal"
-        },
-        {
-            "fieldname": "target_app_name",
-            "fieldtype": "Data",
-            "label": "Target App Name",
-            "reqd": 1,
-            "description": "Frappe app directory name (e.g. ampower_task_manager)"
-        },
-        {
-            "fieldname": "github_repo_url",
-            "fieldtype": "Data",
-            "label": "GitHub Repo URL",
-            "reqd": 1,
-            "description": "e.g. https://github.com/org/repo"
-        },
-        {
-            "fieldname": "github_token",
-            "fieldtype": "Password",
-            "label": "GitHub Token",
-            "description": "Personal Access Token with repo scope"
-        },
-        {
-            "fieldname": "column_break_config",
-            "fieldtype": "Column Break"
-        },
-        {
-            "default": "main",
-            "fieldname": "base_branch",
-            "fieldtype": "Data",
-            "label": "Base Branch"
-        },
-        {
-            "default": "ai-agent/",
-            "fieldname": "branch_prefix",
-            "fieldtype": "Data",
-            "label": "Branch Prefix"
-        },
-        {
-            "default": "AI Agent",
-            "fieldname": "git_user_name",
-            "fieldtype": "Data",
-            "label": "Git User Name"
-        },
-        {
-            "fieldname": "git_user_email",
-            "fieldtype": "Data",
-            "label": "Git User Email",
-            "options": "Email"
-        },
-        {
-            "fieldname": "result_section",
-            "fieldtype": "Section Break",
-            "label": "Pull Request",
-            "depends_on": "eval:doc.pr_url"
-        },
-        {
-            "fieldname": "pr_url",
-            "fieldtype": "Data",
-            "label": "PR URL",
-            "options": "URL",
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_result",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "branch_name",
-            "fieldtype": "Data",
-            "label": "Branch Name",
-            "read_only": 1
-        },
-        {
-            "fieldname": "pr_number",
-            "fieldtype": "Int",
-            "label": "PR Number",
-            "read_only": 1
-        },
-        {
-            "fieldname": "plan_section",
-            "fieldtype": "Section Break",
-            "label": "Agent Plan",
-            "depends_on": "eval:doc.agent_plan"
-        },
-        {
-            "fieldname": "agent_plan",
-            "fieldtype": "Markdown Editor",
-            "label": "Agent Plan"
-        },
-        {
-            "fieldname": "diff_section",
-            "fieldtype": "Section Break",
-            "label": "Patch Diff",
-            "collapsible": 1,
-            "depends_on": "eval:doc.patch_diff"
-        },
-        {
-            "fieldname": "patch_diff",
-            "fieldtype": "Code",
-            "label": "Patch Diff",
-            "options": "Diff",
-            "read_only": 1
-        },
-        {
-            "fieldname": "logs_section",
-            "fieldtype": "Section Break",
-            "label": "Logs",
-            "collapsible": 1,
-            "collapsible_depends_on": "eval:1",
-            "depends_on": "eval:doc.stage_log || doc.bench_log || doc.error_log"
-        },
-        {
-            "fieldname": "stage_log",
-            "fieldtype": "Long Text",
-            "label": "Stage Progress",
-            "read_only": 1
-        },
-        {
-            "fieldname": "bench_log",
-            "fieldtype": "Long Text",
-            "label": "Bench Commands",
-            "read_only": 1
-        },
-        {
-            "fieldname": "error_log",
-            "fieldtype": "Long Text",
-            "label": "Errors",
-            "read_only": 1
-        },
-        {
-            "fieldname": "debug_section",
-            "fieldtype": "Section Break",
-            "label": "Debug Info",
-            "collapsible": 1,
-            "collapsible_depends_on": "eval:1",
-            "depends_on": "eval:doc.conversation_log || doc.files_changed"
-        },
-        {
-            "fieldname": "pending_bench_commands",
-            "fieldtype": "Code",
-            "label": "Pending Bench Commands",
-            "read_only": 1,
-            "hidden": 1
-        },
-        {
-            "fieldname": "conversation_log",
-            "fieldtype": "Long Text",
-            "label": "Conversation Log",
-            "read_only": 1
-        },
-        {
-            "fieldname": "files_changed",
-            "fieldtype": "Long Text",
-            "label": "Files Changed",
-            "read_only": 1
-        },
-        {
-            "fieldname": "tokens_used",
-            "fieldtype": "Int",
-            "label": "Tokens Used",
-            "read_only": 1
-        },
-        {
-            "fieldname": "cost_estimate",
-            "fieldtype": "Currency",
-            "label": "Cost Estimate",
-            "read_only": 1
-        },
-        {
-            "fieldname": "prompts_tab",
-            "fieldtype": "Tab Break",
-            "label": "Prompts"
-        },
-        {
-            "fieldname": "use_default_prompts",
-            "fieldtype": "Check",
-            "label": "Use Default Prompts",
-            "default": 1,
-            "description": "If enabled, system default prompts will be used. Disable to provide custom prompts."
-        },
-        {
-            "fieldname": "prompts_section",
-            "fieldtype": "Section Break",
-            "label": "Custom Prompts",
-            "collapsible": 1,
-            "depends_on": "eval:!doc.use_default_prompts"
-        },
-        {
-            "fieldname": "prompts",
-            "fieldtype": "Table",
-            "label": "Prompts",
-            "options": "Agent Prompt Configuration",
-            "depends_on": "eval:!doc.use_default_prompts"
-        }
-    ],
-    "index_web_pages_for_search": 0,
-    "links": [],
-    "modified": "2026-03-12 10:00:00.000000",
-    "modified_by": "Administrator",
-    "module": "Ampower Koda",
-    "name": "Agent Request",
-    "naming_rule": "Expression",
-    "owner": "Administrator",
-    "permissions": [
-        {
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "System Manager",
-            "share": 1,
-            "write": 1
-        }
-    ],
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": [],
-    "track_changes": 1
+ "actions": [],
+ "autoname": "format:AGENT-{####}",
+ "creation": "2026-03-05 12:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "status_dashboard_html",
+  "request_section",
+  "request_title",
+  "column_break_req1",
+  "request_type",
+  "status",
+  "description_section",
+  "user_message",
+  "model_section",
+  "ai_provider",
+  "column_break_model",
+  "ai_model",
+  "config_section",
+  "target_app_name",
+  "github_repo_url",
+  "github_token",
+  "column_break_config",
+  "base_branch",
+  "branch_prefix",
+  "git_user_name",
+  "git_user_email",
+  "result_section",
+  "pr_url",
+  "column_break_result",
+  "branch_name",
+  "pr_number",
+  "plan_section",
+  "agent_plan",
+  "diff_section",
+  "patch_diff",
+  "logs_section",
+  "stage_log",
+  "bench_log",
+  "error_log",
+  "debug_section",
+  "pending_bench_commands",
+  "conversation_log",
+  "understanding_snapshot",
+  "files_changed",
+  "tokens_used",
+  "cost_estimate",
+  "prompts_tab",
+  "use_default_prompts",
+  "prompts_section",
+  "prompts"
+ ],
+ "fields": [
+  {
+   "fieldname": "status_dashboard_html",
+   "fieldtype": "HTML",
+   "label": "Status Dashboard"
+  },
+  {
+   "fieldname": "request_section",
+   "fieldtype": "Section Break",
+   "label": "Request"
+  },
+  {
+   "fieldname": "request_title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_req1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "request_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Type",
+   "options": "Bug Fix\nReports & analytics\nDocTypes & data model\nForms & desk UI\nServer & business logic\nDocuments & output\nIntegrations\nPlatform & maintenance\nERPNext-flavored",
+   "reqd": 1
+  },
+  {
+   "default": "Queued",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Queued\nUnderstanding\nPlanning\nAwaiting Approval\nImplementing\nReviewing\nAwaiting Bench Approval\nBuilding\nAwaiting Push Approval\nPushing\nCompleted\nFailed\nCancelled",
+   "read_only": 1
+  },
+  {
+   "fieldname": "description_section",
+   "fieldtype": "Section Break",
+   "label": "Description"
+  },
+  {
+   "description": "Describe the bug, feature, or improvement in detail. The more context you provide, the better the result.",
+   "fieldname": "user_message",
+   "fieldtype": "Text Editor",
+   "label": "What do you need?",
+   "reqd": 1
+  },
+  {
+   "fieldname": "model_section",
+   "fieldtype": "Section Break",
+   "label": "AI Model"
+  },
+  {
+   "default": "OpenAI",
+   "fieldname": "ai_provider",
+   "fieldtype": "Select",
+   "label": "Provider",
+   "options": "OpenAI\nGemini\nClaude",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_model",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "gpt-4o-mini",
+   "fieldname": "ai_model",
+   "fieldtype": "Select",
+   "label": "Model",
+   "options": "gpt-4o-mini\ngpt-5-mini\ngpt-5.1-codex-mini\ngpt-5-codex\ngpt-5.1-codex\ngpt-5.2-codex\ngemini-2.0-flash\ngemini-2.5-pro\nclaude-sonnet-4-20250514\nclaude-3-5-sonnet-20241022\nclaude-3-5-haiku-20241022",
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:!doc.__islocal",
+   "fieldname": "config_section",
+   "fieldtype": "Section Break",
+   "label": "Repository & Git Configuration"
+  },
+  {
+   "description": "Frappe app directory name (e.g. ampower_task_manager)",
+   "fieldname": "target_app_name",
+   "fieldtype": "Data",
+   "label": "Target App Name",
+   "reqd": 1
+  },
+  {
+   "description": "e.g. https://github.com/org/repo",
+   "fieldname": "github_repo_url",
+   "fieldtype": "Data",
+   "label": "GitHub Repo URL",
+   "reqd": 1
+  },
+  {
+   "description": "Personal Access Token with repo scope",
+   "fieldname": "github_token",
+   "fieldtype": "Password",
+   "label": "GitHub Token"
+  },
+  {
+   "fieldname": "column_break_config",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "main",
+   "fieldname": "base_branch",
+   "fieldtype": "Data",
+   "label": "Base Branch"
+  },
+  {
+   "default": "ai-agent/",
+   "fieldname": "branch_prefix",
+   "fieldtype": "Data",
+   "label": "Branch Prefix"
+  },
+  {
+   "default": "AI Agent",
+   "fieldname": "git_user_name",
+   "fieldtype": "Data",
+   "label": "Git User Name"
+  },
+  {
+   "fieldname": "git_user_email",
+   "fieldtype": "Data",
+   "label": "Git User Email",
+   "options": "Email"
+  },
+  {
+   "depends_on": "eval:doc.pr_url",
+   "fieldname": "result_section",
+   "fieldtype": "Section Break",
+   "label": "Pull Request"
+  },
+  {
+   "fieldname": "pr_url",
+   "fieldtype": "Data",
+   "label": "PR URL",
+   "options": "URL",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_result",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "branch_name",
+   "fieldtype": "Data",
+   "label": "Branch Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pr_number",
+   "fieldtype": "Int",
+   "label": "PR Number",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.agent_plan",
+   "fieldname": "plan_section",
+   "fieldtype": "Section Break",
+   "label": "Agent Plan"
+  },
+  {
+   "fieldname": "agent_plan",
+   "fieldtype": "Markdown Editor",
+   "label": "Agent Plan"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:doc.patch_diff",
+   "fieldname": "diff_section",
+   "fieldtype": "Section Break",
+   "label": "Patch Diff"
+  },
+  {
+   "fieldname": "patch_diff",
+   "fieldtype": "Code",
+   "label": "Patch Diff",
+   "options": "Diff",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:1",
+   "depends_on": "eval:doc.stage_log || doc.bench_log || doc.error_log",
+   "fieldname": "logs_section",
+   "fieldtype": "Section Break",
+   "label": "Logs"
+  },
+  {
+   "fieldname": "stage_log",
+   "fieldtype": "Long Text",
+   "label": "Stage Progress",
+   "read_only": 1
+  },
+  {
+   "fieldname": "bench_log",
+   "fieldtype": "Long Text",
+   "label": "Bench Commands",
+   "read_only": 1
+  },
+  {
+   "fieldname": "error_log",
+   "fieldtype": "Long Text",
+   "label": "Errors",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:1",
+   "depends_on": "eval:doc.conversation_log || doc.files_changed",
+   "fieldname": "debug_section",
+   "fieldtype": "Section Break",
+   "label": "Debug Info"
+  },
+  {
+   "fieldname": "pending_bench_commands",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Pending Bench Commands",
+   "read_only": 1
+  },
+  {
+   "fieldname": "conversation_log",
+   "fieldtype": "Long Text",
+   "label": "Conversation Log",
+   "read_only": 1
+  },
+  {
+   "description": "Understanding summary captured at planning time. Used as stable context for implementation across runs.",
+   "fieldname": "understanding_snapshot",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Understanding Snapshot",
+   "read_only": 1
+  },
+  {
+   "fieldname": "files_changed",
+   "fieldtype": "JSON",
+   "label": "Files Changed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "tokens_used",
+   "fieldtype": "Int",
+   "label": "Tokens Used",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cost_estimate",
+   "fieldtype": "Currency",
+   "label": "Cost Estimate",
+   "read_only": 1
+  },
+  {
+   "fieldname": "prompts_tab",
+   "fieldtype": "Tab Break",
+   "label": "Prompts"
+  },
+  {
+   "default": "1",
+   "description": "If enabled, system default prompts will be used. Disable to provide custom prompts.",
+   "fieldname": "use_default_prompts",
+   "fieldtype": "Check",
+   "label": "Use Default Prompts"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:!doc.use_default_prompts",
+   "fieldname": "prompts_section",
+   "fieldtype": "Section Break",
+   "label": "Custom Prompts"
+  },
+  {
+   "depends_on": "eval:!doc.use_default_prompts",
+   "fieldname": "prompts",
+   "fieldtype": "Table",
+   "label": "Prompts",
+   "options": "Agent Prompt Configuration"
+  }
+ ],
+ "links": [],
+ "modified": "2026-07-04 12:24:28.352151",
+ "modified_by": "Administrator",
+ "module": "Ampower Koda",
+ "name": "Agent Request",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
@@ -45,6 +45,9 @@
   "pending_bench_commands",
   "conversation_log",
   "understanding_snapshot",
+  "implementation_snapshot",
+  "follow_up_message",
+  "follow_up_count",
   "files_changed",
   "tokens_used",
   "cost_estimate",
@@ -306,6 +309,28 @@
    "fieldtype": "Long Text",
    "hidden": 1,
    "label": "Understanding Snapshot",
+   "read_only": 1
+  },
+  {
+   "description": "What the last implementation run built — used as memory for follow-up patches.",
+   "fieldname": "implementation_snapshot",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Implementation Snapshot",
+   "read_only": 1
+  },
+  {
+   "fieldname": "follow_up_message",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Follow-up Message",
+   "read_only": 1
+  },
+  {
+   "fieldname": "follow_up_count",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Follow-up Count",
    "read_only": 1
   },
   {

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.json
@@ -78,7 +78,7 @@
             "in_list_view": 1,
             "in_standard_filter": 1,
             "label": "Type",
-            "options": "Bug Fix\nFeature Request\nImprovement",
+            "options": "Bug Fix\nReports & analytics\nDocTypes & data model\nForms & desk UI\nServer & business logic\nDocuments & output\nIntegrations\nPlatform & maintenance\nERPNext-flavored",
             "reqd": 1
         },
         {
@@ -127,7 +127,7 @@
             "label": "Model",
             "default": "gpt-4o-mini",
             "reqd": 1,
-            "options": "gpt-4o-mini\ngpt-4o\ngpt-5-mini\no3-mini\ngemini-2.0-flash\ngemini-2.5-pro\nclaude-sonnet-4-20250514\nclaude-3-5-sonnet-20241022\nclaude-3-5-haiku-20241022"
+            "options": "gpt-4o-mini\ngpt-5-mini\ngpt-5.1-codex-mini\ngpt-5-codex\ngpt-5.1-codex\ngpt-5.2-codex\ngemini-2.0-flash\ngemini-2.5-pro\nclaude-sonnet-4-20250514\nclaude-3-5-sonnet-20241022\nclaude-3-5-haiku-20241022"
         },
         {
             "fieldname": "config_section",
@@ -326,7 +326,7 @@
             "fieldname": "prompts",
             "fieldtype": "Table",
             "label": "Prompts",
-            "options": "AI Agent Prompt Configuration",
+            "options": "Agent Prompt Configuration",
             "depends_on": "eval:!doc.use_default_prompts"
         }
     ],
@@ -335,7 +335,7 @@
     "modified": "2026-03-12 10:00:00.000000",
     "modified_by": "Administrator",
     "module": "Ampower Koda",
-    "name": "AI Agent Request",
+    "name": "Agent Request",
     "naming_rule": "Expression",
     "owner": "Administrator",
     "permissions": [

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.py
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.py
@@ -5,16 +5,16 @@ import frappe
 from frappe.model.document import Document
 
 
-class AIAgentRequest(Document):
+class AgentRequest(Document):
     def before_insert(self):
         if not self.owner:
             self.owner = frappe.session.user
         self._set_defaults_from_settings()
 
     def _set_defaults_from_settings(self):
-        """Populate provider/model defaults from AI Agent Settings if not already set."""
+        """Populate provider/model defaults from Agent Settings if not already set."""
         try:
-            settings = frappe.get_single("AI Agent Settings")
+            settings = frappe.get_single("Agent Settings")
             if not self.ai_provider:
                 self.ai_provider = settings.default_ai_provider or "OpenAI"
             if not self.ai_model:
@@ -28,15 +28,12 @@ class AIAgentRequest(Document):
         if not self.github_repo_url or not self.github_repo_url.strip():
             frappe.throw("GitHub Repo URL is required")
 
-        # Password fields need get_password() for value check on existing docs;
-        # on new docs the value is in self.github_token directly
         token = self.github_token
         if not self.is_new():
             token = self.get_password("github_token", raise_exception=False)
         if not token:
             frappe.throw("GitHub Token is required")
 
-        # Prevent duplicate prompt types
         if not self.use_default_prompts:
             seen = set()
             for row in self.prompts:

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.py
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.py
@@ -2,7 +2,10 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
+
+from ampower_koda.agent.errors import log_agent_error
 
 
 class AgentRequest(Document):
@@ -20,23 +23,26 @@ class AgentRequest(Document):
             if not self.ai_model:
                 self.ai_model = settings.default_ai_model or "gpt-4o-mini"
         except Exception:
-            pass
+            log_agent_error(
+                "Agent Request: defaults from settings",
+                frappe.get_traceback(),
+            )
 
     def validate(self):
-        if not self.target_app_name or not self.target_app_name.strip():
-            frappe.throw("Target App Name is required")
-        if not self.github_repo_url or not self.github_repo_url.strip():
-            frappe.throw("GitHub Repo URL is required")
+        if not (self.target_app_name or "").strip():
+            frappe.throw(_("Target App Name is required"))
+        if not (self.github_repo_url or "").strip():
+            frappe.throw(_("GitHub Repo URL is required"))
 
         token = self.github_token
         if not self.is_new():
             token = self.get_password("github_token", raise_exception=False)
         if not token:
-            frappe.throw("GitHub Token is required")
+            frappe.throw(_("GitHub Token is required"))
 
         if not self.use_default_prompts:
             seen = set()
             for row in self.prompts:
                 if row.prompt_key in seen:
-                    frappe.throw(f"Duplicate prompt type not allowed: {row.prompt_key}")
+                    frappe.throw(_("Duplicate prompt type not allowed: {0}").format(row.prompt_key))
                 seen.add(row.prompt_key)

--- a/ampower_koda/ampower_koda/doctype/agent_request/agent_request.py
+++ b/ampower_koda/ampower_koda/doctype/agent_request/agent_request.py
@@ -14,6 +14,13 @@ class AgentRequest(Document):
             self.owner = frappe.session.user
         self._set_defaults_from_settings()
 
+    def _normalize_json_fields(self):
+        """Blank JSON fields must be NULL, not '' — empty strings fail json_valid()."""
+        for df in self.meta.get("fields", {"fieldtype": "JSON"}):
+            value = self.get(df.fieldname)
+            if isinstance(value, str) and not value.strip():
+                self.set(df.fieldname, None)
+
     def _set_defaults_from_settings(self):
         """Populate provider/model defaults from Agent Settings if not already set."""
         try:
@@ -29,6 +36,8 @@ class AgentRequest(Document):
             )
 
     def validate(self):
+        self._normalize_json_fields()
+
         if not (self.target_app_name or "").strip():
             frappe.throw(_("Target App Name is required"))
         if not (self.github_repo_url or "").strip():

--- a/ampower_koda/ampower_koda/doctype/agent_request/test_agent_request.py
+++ b/ampower_koda/ampower_koda/doctype/agent_request/test_agent_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Ambibuzz Technologies LLP and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAgentRequest(FrappeTestCase):
+	pass

--- a/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.js
+++ b/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.js
@@ -1,12 +1,14 @@
 // Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
-// AI Agent Settings — client script
+// Agent Settings — client script
 
 var PROVIDER_MODELS = {
     'OpenAI': [
         { value: 'gpt-4o-mini', label: 'GPT-4o Mini — fast, cost-effective' },
-        { value: 'gpt-4o', label: 'GPT-4o — best overall' },
         { value: 'gpt-5-mini', label: 'GPT-5 Mini — next-gen, efficient' },
-        { value: 'o3-mini', label: 'o3-mini — reasoning model' }
+        { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini — compact coding' },
+        { value: 'gpt-5-codex', label: 'GPT-5 Codex — coding model' },
+        { value: 'gpt-5.1-codex', label: 'GPT-5.1 Codex — coding model' },
+        { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex — latest coding model' }
     ],
     'Gemini': [
         { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash — fast, multimodal' },
@@ -25,7 +27,7 @@ var DEFAULT_MODELS = {
     'Claude': 'claude-sonnet-4-20250514'
 };
 
-frappe.ui.form.on('AI Agent Settings', {
+frappe.ui.form.on('Agent Settings', {
     refresh: function(frm) {
         set_model_options_for_provider(frm);
     },

--- a/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.json
+++ b/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.json
@@ -58,7 +58,7 @@
             "fieldtype": "Select",
             "label": "AI Model",
             "default": "gpt-4o-mini",
-            "options": "gpt-4o-mini\ngpt-4o\ngpt-5-mini\no3-mini\ngemini-2.0-flash\ngemini-2.5-pro\nclaude-sonnet-4-20250514\nclaude-3-5-sonnet-20241022\nclaude-3-5-haiku-20241022",
+            "options": "gpt-4o-mini\ngpt-5-mini\ngpt-5.1-codex-mini\ngpt-5-codex\ngpt-5.1-codex\ngpt-5.2-codex\ngemini-2.0-flash\ngemini-2.5-pro\nclaude-sonnet-4-20250514\nclaude-3-5-sonnet-20241022\nclaude-3-5-haiku-20241022",
             "description": "Default model for new requests. Changes with provider selection."
         },
         {
@@ -111,7 +111,7 @@
     "modified": "2026-03-31 20:30:00.000000",
     "modified_by": "Administrator",
     "module": "Ampower Koda",
-    "name": "AI Agent Settings",
+    "name": "Agent Settings",
     "owner": "Administrator",
     "permissions": [
         {

--- a/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.py
+++ b/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -18,4 +19,6 @@ class AgentSettings(Document):
         }
         field, label = key_map.get(provider, key_map["OpenAI"])
         if not getattr(self, field, None):
-            frappe.throw(f"{label} is required when {provider} is the default provider")
+            frappe.throw(
+                _("{0} is required when {1} is the default provider").format(label, provider)
+            )

--- a/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.py
+++ b/ampower_koda/ampower_koda/doctype/agent_settings/agent_settings.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.model.document import Document
 
 
-class AIAgentSettings(Document):
+class AgentSettings(Document):
     def validate(self):
         if not self.enable_ai_agent:
             return

--- a/ampower_koda/ampower_koda/doctype/ai_agent_settings/ai_agent_settings.json
+++ b/ampower_koda/ampower_koda/doctype/ai_agent_settings/ai_agent_settings.json
@@ -108,7 +108,7 @@
     ],
     "issingle": 1,
     "links": [],
-    "modified": "2026-03-27 12:00:00.000000",
+    "modified": "2026-03-31 20:30:00.000000",
     "modified_by": "Administrator",
     "module": "Ampower Koda",
     "name": "AI Agent Settings",

--- a/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.html
+++ b/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.html
@@ -1,0 +1,1 @@
+<div class="agent-diff-viewer-page"></div>

--- a/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.html
+++ b/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.html
@@ -1,1 +1,0 @@
-<div class="agent-diff-viewer-page"></div>

--- a/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.js
+++ b/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.js
@@ -1,0 +1,1137 @@
+/* global ace */
+
+frappe.pages['agent-diff-viewer'].on_page_load = function (wrapper) {
+    const route = frappe.get_route();
+    const request_name = route[1];
+
+    const page = frappe.ui.make_app_page({
+        parent: wrapper,
+        title: __('Agent IDE'),
+        single_column: true,
+    });
+
+    const ide = {
+        request_name: request_name,
+        context: {},
+        treeData: null,
+        files: {},
+        activePath: null,
+        editor: null,
+        aceReady: null,
+        viewMode: 'code',
+        dirtyPaths: new Set(),
+    };
+
+    inject_ide_styles();
+    const $shell = build_ide_shell(page, ide);
+    page.main.append($shell);
+    bind_ide_shortcuts(ide, $shell);
+
+    if (!request_name) {
+        show_ide_error($shell, __('Open this page from an Agent Request.'));
+        return;
+    }
+
+    load_ace().then(function () {
+        init_editor($shell, ide);
+        load_workspace(request_name, $shell, ide);
+    });
+};
+
+function load_ace() {
+    const root = frappe.boot.developer_mode
+        ? '/assets/frappe/node_modules/ace-builds/src-noconflict/'
+        : '/assets/frappe/node_modules/ace-builds/src-min-noconflict/';
+    return new Promise(function (resolve) {
+        frappe.require(root + 'ace.js', function () {
+            window.ace.config.set('basePath', root);
+            resolve();
+        });
+    });
+}
+
+function inject_ide_styles() {
+    let style = document.getElementById('agent-ide-styles');
+    if (!style) {
+        style = document.createElement('style');
+        style.id = 'agent-ide-styles';
+        document.head.appendChild(style);
+    }
+    style.textContent = `
+        .koda-ide {
+            --bg: #0d1117;
+            --panel: #161b22;
+            --panel-2: #1c2129;
+            --hover: #21262d;
+            --border: #30363d;
+            --text: #e6edf3;
+            --muted: #8b949e;
+            --accent: #388bfd;
+            --accent-hover: #4d9bff;
+            --green: #3fb950;
+            --red: #f85149;
+            --amber: #e3b341;
+        }
+        .koda-ide.koda-light {
+            --bg: #ffffff;
+            --panel: #f6f8fa;
+            --panel-2: #eef1f4;
+            --hover: #eaeef2;
+            --border: #d0d7de;
+            --text: #1f2328;
+            --muted: #656d76;
+            --accent: #0969da;
+            --accent-hover: #0860ca;
+            --green: #1a7f37;
+            --red: #cf222e;
+            --amber: #9a6700;
+        }
+        .layout-main-section .page-content:has(.koda-ide) {
+            padding: 0 !important;
+        }
+        .koda-ide {
+            display: flex;
+            flex-direction: column;
+            height: calc(100vh - 108px);
+            min-height: 600px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            overflow: hidden;
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+        .koda-ide button {
+            font-family: inherit;
+            cursor: pointer;
+            opacity: 1;
+        }
+        .koda-ide button:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+        }
+        .koda-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 4px;
+            font-size: 12px;
+            font-weight: 500;
+            line-height: 1;
+            padding: 6px 12px;
+            border-radius: 5px;
+            border: 1px solid var(--border);
+            background: var(--panel);
+            color: var(--text);
+            opacity: 1;
+            transition: background 0.1s, border-color 0.1s;
+        }
+        .koda-btn:hover:not(:disabled) {
+            background: var(--hover);
+            border-color: var(--border);
+            color: var(--text);
+            opacity: 1;
+        }
+        .koda-btn-primary {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: #fff;
+        }
+        .koda-btn-primary:hover:not(:disabled) {
+            background: var(--accent-hover);
+            border-color: var(--accent-hover);
+            color: #fff;
+            opacity: 1;
+        }
+        .koda-btn-ghost {
+            background: transparent;
+            border-color: var(--border);
+            color: var(--text);
+        }
+        .koda-btn-sm {
+            font-size: 11px;
+            padding: 4px 8px;
+        }
+        .koda-toolbar {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 12px;
+            background: var(--panel);
+            border-bottom: 1px solid var(--border);
+            flex-wrap: wrap;
+        }
+        .koda-toolbar .koda-title {
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text);
+        }
+        .koda-toolbar .koda-meta {
+            font-size: 11px;
+            color: var(--muted);
+            margin-right: auto;
+            max-width: 40%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .koda-toolbar .koda-meta b { color: var(--text); font-weight: 600; }
+        .koda-toolbar-actions {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .koda-sep {
+            width: 1px;
+            height: 20px;
+            background: var(--border);
+            flex-shrink: 0;
+        }
+        .koda-view-group {
+            display: inline-flex;
+            border: 1px solid var(--border);
+            border-radius: 5px;
+            overflow: hidden;
+        }
+        .koda-view-group .koda-btn {
+            border: none;
+            border-radius: 0;
+            border-right: 1px solid var(--border);
+        }
+        .koda-view-group .koda-btn:last-child { border-right: none; }
+        .koda-view-group .koda-btn.active {
+            background: var(--accent);
+            color: #fff;
+        }
+        .koda-view-group .koda-btn.active:hover:not(:disabled) {
+            background: var(--accent-hover);
+            color: #fff;
+            opacity: 1;
+        }
+        .koda-body {
+            display: flex;
+            flex: 1;
+            min-height: 0;
+        }
+        .koda-sidebar {
+            width: 240px;
+            min-width: 160px;
+            max-width: 360px;
+            background: var(--panel);
+            border-right: 1px solid var(--border);
+            overflow: auto;
+            font-size: 12px;
+            resize: horizontal;
+        }
+        .koda-sidebar-title {
+            padding: 8px 12px;
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--muted);
+            border-bottom: 1px solid var(--border);
+            position: sticky;
+            top: 0;
+            background: var(--panel);
+            z-index: 1;
+        }
+        .koda-main {
+            flex: 1;
+            min-width: 0;
+            display: flex;
+            flex-direction: column;
+            background: var(--bg);
+        }
+        .koda-tabs {
+            display: flex;
+            background: var(--panel);
+            border-bottom: 1px solid var(--border);
+            min-height: 32px;
+            overflow-x: auto;
+        }
+        .koda-tab {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 7px 10px 7px 12px;
+            font-size: 12px;
+            color: var(--muted);
+            border-right: 1px solid var(--border);
+            cursor: pointer;
+            white-space: nowrap;
+        }
+        .koda-tab:hover { background: var(--hover); color: var(--text); }
+        .koda-tab.active { background: var(--bg); color: var(--text); }
+        .koda-tab-label { pointer-events: none; }
+        .koda-tab.dirty .koda-tab-label::after { content: ' *'; color: var(--amber); }
+        .koda-tab-close {
+            display: none;
+            width: 16px;
+            height: 16px;
+            align-items: center;
+            justify-content: center;
+            border-radius: 3px;
+            font-size: 14px;
+            line-height: 1;
+            color: var(--muted);
+            flex-shrink: 0;
+        }
+        .koda-tab:hover .koda-tab-close { display: inline-flex; }
+        .koda-tab-close:hover {
+            background: var(--hover);
+            color: var(--text);
+        }
+        .koda-editor-wrap {
+            flex: 1;
+            min-height: 0;
+            position: relative;
+        }
+        .koda-editor-empty {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--muted);
+            font-size: 13px;
+            pointer-events: none;
+            z-index: 1;
+        }
+        .koda-editor-wrap.has-file .koda-editor-empty { display: none; }
+        .koda-breadcrumb {
+            padding: 5px 12px;
+            font-size: 11px;
+            color: var(--muted);
+            background: var(--panel-2);
+            border-bottom: 1px solid var(--border);
+            font-family: ui-monospace, Menlo, monospace;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .koda-ace-target { position: absolute; inset: 0; }
+        .koda-diff-wrap {
+            flex: 1;
+            min-height: 0;
+            overflow: auto;
+            display: none;
+            background: var(--bg);
+        }
+        .koda-diff-only .koda-editor-wrap { display: none; }
+        .koda-diff-only .koda-diff-wrap { display: block; flex: 1; }
+        .koda-diff-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-family: ui-monospace, Menlo, monospace;
+            font-size: 12px;
+        }
+        .koda-diff-table td {
+            padding: 1px 10px;
+            vertical-align: top;
+            white-space: pre-wrap;
+            word-break: break-word;
+            line-height: 1.45;
+        }
+        .koda-line-no {
+            width: 44px;
+            text-align: right;
+            color: var(--muted);
+            border-right: 1px solid var(--border);
+            user-select: none;
+            background: var(--panel);
+        }
+        .koda-line-add { background: rgba(46, 160, 67, 0.12); }
+        .koda-line-add td:last-child { color: var(--green); }
+        .koda-line-del { background: rgba(248, 81, 73, 0.12); }
+        .koda-line-del td:last-child { color: var(--red); }
+        .koda-line-hunk { background: rgba(56, 139, 253, 0.08); color: var(--accent); }
+        .koda-terminal {
+            height: 120px;
+            min-height: 72px;
+            max-height: 40vh;
+            background: var(--panel);
+            border-top: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+            resize: vertical;
+            overflow: hidden;
+        }
+        .koda-terminal.collapsed {
+            height: 28px !important;
+            min-height: 28px;
+            resize: none;
+        }
+        .koda-terminal.collapsed .koda-terminal-body { display: none; }
+        .koda-terminal-header {
+            padding: 4px 10px;
+            font-size: 11px;
+            color: var(--muted);
+            background: var(--panel-2);
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .koda-terminal-body {
+            flex: 1;
+            overflow: auto;
+            padding: 8px 10px;
+            font-family: ui-monospace, Menlo, monospace;
+            font-size: 11px;
+            line-height: 1.5;
+            color: var(--muted);
+            white-space: pre-wrap;
+        }
+        .koda-tree-row {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            cursor: pointer;
+            color: var(--text);
+        }
+        .koda-tree-row:hover { background: var(--hover); }
+        .koda-tree-row.selected { background: var(--hover); font-weight: 500; }
+        .koda-tree-row.changed { color: var(--amber); }
+        .koda-tree-row.dimmed { color: var(--muted); }
+        .koda-tree-row .koda-tree-name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .koda-badge {
+            margin-left: auto;
+            font-size: 9px;
+            font-weight: 600;
+            padding: 1px 4px;
+            border-radius: 3px;
+            flex-shrink: 0;
+        }
+        .koda-badge-M { background: rgba(227, 179, 65, 0.15); color: var(--amber); }
+        .koda-badge-A { background: rgba(63, 185, 80, 0.15); color: var(--green); }
+        .koda-badge-D { background: rgba(248, 81, 73, 0.15); color: var(--red); }
+        .koda-empty {
+            padding: 20px;
+            text-align: center;
+            color: var(--muted);
+            font-size: 12px;
+        }
+        .koda-statusbar {
+            padding: 4px 12px;
+            font-size: 11px;
+            color: var(--muted);
+            background: var(--panel);
+            border-top: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+        }
+        .koda-statusbar .koda-status-path {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-family: ui-monospace, Menlo, monospace;
+        }
+    `;
+}
+
+function build_ide_shell(page, ide) {
+    const $shell = $(`
+        <div class="koda-ide">
+            <div class="koda-toolbar">
+                <span class="koda-title">${__('Agent IDE')}</span>
+                <span class="koda-meta koda-toolbar-meta">${__('Loading...')}</span>
+                <div class="koda-toolbar-actions">
+                    <button type="button" class="koda-btn koda-btn-primary koda-btn-save" disabled title="Ctrl+S">${__('Save')}</button>
+                    <span class="koda-sep"></span>
+                    <button type="button" class="koda-btn koda-btn-ghost koda-btn-deploy">${__('Deploy')}</button>
+                    <button type="button" class="koda-btn koda-btn-ghost koda-btn-push">${__('Push')}</button>
+                    <span class="koda-sep"></span>
+                    <div class="koda-view-group">
+                        <button type="button" class="koda-btn active koda-view-btn" data-mode="code">${__('Code')}</button>
+                        <button type="button" class="koda-btn koda-view-btn" data-mode="diff">${__('Diff')}</button>
+                    </div>
+                    <span class="koda-sep"></span>
+                    <button type="button" class="koda-btn koda-btn-ghost koda-theme-btn" title="${__('Toggle theme')}">🌙</button>
+                </div>
+            </div>
+            <div class="koda-body">
+                <div class="koda-sidebar">
+                    <div class="koda-sidebar-title">${__('Files')}</div>
+                    <div class="koda-tree"><div class="koda-empty">${__('Loading...')}</div></div>
+                </div>
+                <div class="koda-main">
+                    <div class="koda-tabs"></div>
+                    <div class="koda-breadcrumb koda-breadcrumb-path"></div>
+                    <div class="koda-editor-wrap">
+                        <div class="koda-editor-empty">${__('Select a file to edit')}</div>
+                        <div class="koda-ace-target"></div>
+                    </div>
+                    <div class="koda-diff-wrap"><div class="koda-diff-content"></div></div>
+                    <div class="koda-statusbar">
+                        <span class="koda-status-text">${__('Ready')}</span>
+                        <span class="koda-status-path"></span>
+                    </div>
+                </div>
+            </div>
+            <div class="koda-terminal">
+                <div class="koda-terminal-header">
+                    <span>${__('Output')}</span>
+                    <span>
+                        <button type="button" class="koda-btn koda-btn-ghost koda-btn-sm koda-toggle-terminal">${__('Hide')}</button>
+                        <button type="button" class="koda-btn koda-btn-ghost koda-btn-sm koda-clear-terminal">${__('Clear')}</button>
+                    </span>
+                </div>
+                <div class="koda-terminal-body"></div>
+            </div>
+        </div>
+    `);
+
+    page.add_button(__('Back to Request'), function () {
+        frappe.set_route('Form', 'Agent Request', ide.request_name);
+    });
+
+    page.add_button(__('Refresh'), function () {
+        load_workspace(ide.request_name, $shell, ide);
+    });
+
+    $shell.find('.koda-btn-save').on('click', function () {
+        save_active_file($shell, ide);
+    });
+
+    $shell.find('.koda-btn-deploy').on('click', function () {
+        open_deploy_dialog(ide, $shell);
+    });
+
+    $shell.find('.koda-btn-push').on('click', function () {
+        open_push_dialog(ide, $shell);
+    });
+
+    $shell.find('.koda-view-btn').on('click', function () {
+        $shell.find('.koda-view-btn').removeClass('active');
+        $(this).addClass('active');
+        ide.viewMode = $(this).data('mode');
+        apply_view_mode($shell, ide);
+    });
+
+    $shell.find('.koda-clear-terminal').on('click', function () {
+        $shell.find('.koda-terminal-body').empty();
+    });
+
+    $shell.find('.koda-toggle-terminal').on('click', function () {
+        const $term = $shell.find('.koda-terminal');
+        $term.toggleClass('collapsed');
+        $(this).text($term.hasClass('collapsed') ? __('Show') : __('Hide'));
+        if (ide.editor) setTimeout(function () { ide.editor.resize(); }, 50);
+    });
+
+    $shell.find('.koda-theme-btn').on('click', function () {
+        const next = ide.theme === 'light' ? 'dark' : 'light';
+        apply_theme(next, $shell, ide);
+    });
+
+    apply_theme(get_saved_theme(), $shell, ide);
+
+    return $shell;
+}
+
+function get_saved_theme() {
+    try {
+        return localStorage.getItem('koda_ide_theme') === 'light' ? 'light' : 'dark';
+    } catch (e) {
+        return 'dark';
+    }
+}
+
+function apply_theme(theme, $shell, ide) {
+    ide.theme = theme === 'light' ? 'light' : 'dark';
+    const $ide = $shell.hasClass('koda-ide') ? $shell : $shell.find('.koda-ide');
+    $ide.toggleClass('koda-light', ide.theme === 'light');
+
+    const $btn = $shell.find('.koda-theme-btn');
+    $btn.text(ide.theme === 'light' ? '☀️' : '🌙');
+    $btn.attr('title', ide.theme === 'light' ? __('Switch to dark') : __('Switch to light'));
+
+    if (ide.editor) {
+        ide.editor.setTheme(ide.theme === 'light' ? 'ace/theme/github' : 'ace/theme/one_dark');
+    }
+
+    try {
+        localStorage.setItem('koda_ide_theme', ide.theme);
+    } catch (e) { /* ignore */ }
+}
+
+function bind_ide_shortcuts(ide, $shell) {
+    $(document).on('keydown.koda-ide', function (e) {
+        if (!ide.activePath) return;
+        if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+            e.preventDefault();
+            save_active_file($shell, ide);
+        }
+    });
+}
+
+function init_editor($shell, ide) {
+    const target = $shell.find('.koda-ace-target').get(0);
+    ide.editor = ace.edit(target);
+    ide.editor.setTheme(ide.theme === 'light' ? 'ace/theme/github' : 'ace/theme/one_dark');
+    ide.editor.setShowPrintMargin(false);
+    ide.editor.setOptions({
+        fontSize: 13,
+        wrap: true,
+        enableBasicAutocompletion: true,
+        highlightActiveLine: true,
+        highlightGutterLine: true,
+        showFoldWidgets: true,
+        tabSize: 4,
+        useSoftTabs: true,
+        scrollPastEnd: 0.5,
+    });
+    ide.editor.setKeyboardHandler('ace/keyboard/vscode');
+    ide.editor.session.on('change', frappe.utils.debounce(function () {
+        if (!ide.activePath || ide._setting_content) return;
+        const file = ide.files[ide.activePath];
+        if (!file) return;
+        file.content = ide.editor.getValue();
+        file.dirty = file.content !== file.original;
+        if (file.dirty) {
+            ide.dirtyPaths.add(ide.activePath);
+        } else {
+            ide.dirtyPaths.delete(ide.activePath);
+        }
+        update_tabs($shell, ide);
+        update_save_button($shell, ide);
+        set_status($shell, file.dirty ? __('Unsaved changes — press Save or Ctrl+S') : __('Ready'), file.full_path || ide.activePath);
+    }, 200));
+    ide.editor.resize();
+}
+
+function load_workspace(request_name, $shell, ide) {
+    ide.request_name = request_name;
+    $shell.find('.koda-tree').html(`<div class="koda-empty">${__('Loading...')}</div>`);
+
+    frappe.call({
+        method: 'ampower_koda.agent.api.get_change_tree',
+        args: { request_name: request_name },
+        callback: function (r) {
+            if (!r.message) {
+                show_ide_error($shell, __('Could not load workspace.'));
+                return;
+            }
+            ide.context = r.message;
+            ide.treeData = r.message.tree;
+            render_toolbar_meta($shell, r.message);
+            render_tree($shell, ide, r.message);
+            const first = find_first_changed_file(r.message.tree || []);
+            if (first) {
+                open_file(first.path, $shell, ide);
+            }
+        },
+    });
+}
+
+function render_toolbar_meta($shell, data) {
+    const branch = data.branch_name || '—';
+    const count = (data.totals && data.totals.files) || Object.keys(data.changed || {}).length;
+    const status = (data.request && data.request.status) || '';
+    $shell.find('.koda-toolbar-meta').html(
+        `${frappe.utils.escape_html(data.app_name || '')} · `
+        + `${count} ${__('changed')} · `
+        + `${__('branch')}: <b>${frappe.utils.escape_html(branch)}</b> · `
+        + `${__('status')}: ${frappe.utils.escape_html(status)}`
+    );
+}
+
+function render_tree($shell, ide, data) {
+    const $tree = $shell.find('.koda-tree').empty();
+    if (!data.tree || !data.tree.length) {
+        $tree.html(`<div class="koda-empty">${__('No files found.')}</div>`);
+        return;
+    }
+    const $root = $('<div></div>');
+    data.tree.forEach(function (node) {
+        $root.append(render_tree_node(node, 0, data.changed || {}, $shell, ide));
+    });
+    $tree.append($root);
+}
+
+function render_tree_node(node, depth, changed_map, $shell, ide) {
+    const indent = depth * 12;
+    const $item = $('<div></div>');
+
+    if (node.type === 'folder') {
+        const expanded = node.has_changes;
+        const $row = $(`
+            <div class="koda-tree-row ${node.has_changes ? 'changed' : 'dimmed'}" style="padding-left:${8 + indent}px">
+                <span class="koda-caret">${expanded ? '▾' : '▸'}</span>
+                <span class="koda-tree-name">${frappe.utils.escape_html(node.name)}</span>
+                ${node.changed_count ? `<span class="koda-badge koda-badge-M">${node.changed_count}</span>` : ''}
+            </div>
+        `);
+        const $children = $('<div></div>');
+        if (!expanded) $children.hide();
+        (node.children || []).forEach(function (child) {
+            $children.append(render_tree_node(child, depth + 1, changed_map, $shell, ide));
+        });
+        $row.on('click', function (e) {
+            e.stopPropagation();
+            const open = $children.is(':visible');
+            $children.toggle(!open);
+            $row.find('.koda-caret').text(open ? '▸' : '▾');
+        });
+        $item.append($row, $children);
+        return $item;
+    }
+
+    const status = node.status || '';
+    const dirty = ide.dirtyPaths.has(node.path);
+    const $row = $(`
+        <div class="koda-tree-row ${node.has_changes ? 'changed' : 'dimmed'} ${dirty ? 'dirty' : ''}"
+             data-path="${frappe.utils.escape_html(node.path)}"
+             style="padding-left:${12 + indent}px">
+            <span class="koda-tree-name">${frappe.utils.escape_html(node.name)}${dirty ? ' •' : ''}</span>
+            ${status ? `<span class="koda-badge koda-badge-${status}">${status}</span>` : ''}
+        </div>
+    `);
+    $row.on('click', function () {
+        open_file(node.path, $shell, ide);
+    });
+    $item.append($row);
+    return $item;
+}
+
+function open_file(file_path, $shell, ide, force) {
+    if (!file_path) return;
+
+    const proceed = function () {
+        do_open_file(file_path, $shell, ide);
+    };
+
+    if (!force && ide.activePath && ide.files[ide.activePath] && ide.files[ide.activePath].dirty) {
+        frappe.confirm(
+            __('You have unsaved changes in the current file. Open another file anyway?'),
+            proceed
+        );
+        return;
+    }
+    proceed();
+}
+
+function do_open_file(file_path, $shell, ide) {
+    if (ide.activePath && ide.files[ide.activePath]) {
+        ide.files[ide.activePath].content = ide.editor.getValue();
+    }
+
+    ide.activePath = file_path;
+    $shell.find('.koda-tree-row').removeClass('selected');
+    $shell.find('.koda-tree-row').filter(function () {
+        return $(this).attr('data-path') === file_path;
+    }).addClass('selected');
+
+    const loadAndShow = function (content, language, full_path) {
+        ide.files[file_path] = ide.files[file_path] || {};
+        const cached = ide.files[file_path];
+        if (cached.content !== undefined && cached.dirty) {
+            set_editor_content(ide, cached.content, language);
+        } else {
+            cached.original = content;
+            cached.content = content;
+            cached.dirty = false;
+            cached.language = language;
+            cached.full_path = full_path || cached.full_path;
+            set_editor_content(ide, content, language);
+        }
+        $shell.find('.koda-editor-wrap').addClass('has-file');
+        update_breadcrumb($shell, file_path, cached.full_path);
+        update_tabs($shell, ide);
+        update_save_button($shell, ide);
+        set_status($shell, cached.full_path || file_path, cached.full_path || file_path);
+        load_file_diff(file_path, $shell, ide);
+    };
+
+    if (ide.files[file_path] && ide.files[file_path].content !== undefined) {
+        const cached = ide.files[file_path];
+        loadAndShow(cached.content, cached.language, cached.full_path);
+        return;
+    }
+
+    frappe.call({
+        method: 'ampower_koda.agent.api.get_file_content',
+        args: { request_name: ide.request_name, file_path: file_path },
+        callback: function (r) {
+            if (!r.message) return;
+            loadAndShow(r.message.content || '', r.message.language || 'Text', r.message.full_path);
+        },
+        error: function () {
+            append_terminal($shell, __('Failed to load file: ') + file_path);
+        },
+    });
+}
+
+function set_editor_content(ide, content, language) {
+    const mode_map = {
+        Python: 'ace/mode/python',
+        Javascript: 'ace/mode/javascript',
+        JSON: 'ace/mode/json',
+        HTML: 'ace/mode/html',
+        CSS: 'ace/mode/css',
+        Markdown: 'ace/mode/markdown',
+    };
+    ide._setting_content = true;
+    ide.editor.session.setValue(content || '');
+    ide.editor.session.setMode(mode_map[language] || 'ace/mode/text');
+    ide._setting_content = false;
+    ide.editor.resize();
+    ide.editor.focus();
+}
+
+function format_display_path(path) {
+    if (!path) return '';
+    const prefix = '/opt/bench/frappe-bench/apps/';
+    if (path.startsWith(prefix)) {
+        return path.slice(prefix.length);
+    }
+    return path;
+}
+
+function update_tabs($shell, ide) {
+    const $tabs = $shell.find('.koda-tabs').empty();
+    Object.keys(ide.files).forEach(function (path) {
+        const file = ide.files[path];
+        const name = path.split('/').pop();
+        const $tab = $(`
+            <div class="koda-tab ${path === ide.activePath ? 'active' : ''} ${file.dirty ? 'dirty' : ''}" data-path="${frappe.utils.escape_html(path)}">
+                <span class="koda-tab-label">${frappe.utils.escape_html(name)}</span>
+                <span class="koda-tab-close" title="${__('Close')}">×</span>
+            </div>
+        `);
+        $tab.on('click', function () {
+            open_file(path, $shell, ide);
+        });
+        $tab.find('.koda-tab-close').on('click', function (e) {
+            e.stopPropagation();
+            close_tab(path, $shell, ide);
+        });
+        $tabs.append($tab);
+    });
+}
+
+function close_tab(file_path, $shell, ide) {
+    const file = ide.files[file_path];
+    const do_close = function () {
+        const was_active = ide.activePath === file_path;
+        delete ide.files[file_path];
+        ide.dirtyPaths.delete(file_path);
+
+        if (was_active) {
+            const remaining = Object.keys(ide.files);
+            if (remaining.length) {
+                open_file(remaining[remaining.length - 1], $shell, ide, true);
+            } else {
+                ide.activePath = null;
+                ide._setting_content = true;
+                ide.editor.session.setValue('');
+                ide._setting_content = false;
+                $shell.find('.koda-editor-wrap').removeClass('has-file');
+                update_breadcrumb($shell, '', '');
+                set_status($shell, __('Ready'), '');
+                $shell.find('.koda-diff-content').empty();
+            }
+        }
+        update_tabs($shell, ide);
+        $shell.find('.koda-tree-row').removeClass('selected');
+        if (ide.activePath) {
+            $shell.find('.koda-tree-row').filter(function () {
+                return $(this).attr('data-path') === ide.activePath;
+            }).addClass('selected');
+        }
+    };
+
+    if (file && file.dirty) {
+        frappe.confirm(__('Discard unsaved changes in this file?'), do_close);
+        return;
+    }
+    do_close();
+}
+
+function save_active_file($shell, ide) {
+    const path = ide.activePath;
+    if (!path || !ide.files[path] || !ide.files[path].dirty) return;
+
+    const content = ide.editor.getValue();
+    $shell.find('.koda-btn-save').prop('disabled', true);
+    set_status($shell, __('Saving to disk...'), path);
+
+    frappe.call({
+        method: 'ampower_koda.agent.api.save_file_content',
+        args: {
+            request_name: ide.request_name,
+            file_path: path,
+            content: content,
+        },
+        callback: function (r) {
+            if (r.message && r.message.status === 'ok') {
+                const full_path = r.message.full_path || path;
+                ide.files[path].original = content;
+                ide.files[path].dirty = false;
+                ide.files[path].full_path = full_path;
+                ide.dirtyPaths.delete(path);
+                append_terminal($shell, __('Saved to disk: ') + format_display_path(full_path));
+                frappe.show_alert({
+                    message: __('File saved to codebase'),
+                    indicator: 'green',
+                });
+                set_status($shell, __('Saved'), full_path);
+                update_breadcrumb($shell, path, full_path);
+                update_tabs($shell, ide);
+                update_save_button($shell, ide);
+                load_file_diff(path, $shell, ide);
+                refresh_tree_badges($shell, ide);
+                // Re-read from disk so editor matches what is on the server
+                frappe.call({
+                    method: 'ampower_koda.agent.api.get_file_content',
+                    args: { request_name: ide.request_name, file_path: path },
+                    callback: function (reload) {
+                        if (!reload.message) return;
+                        ide.files[path].original = reload.message.content;
+                        ide.files[path].content = reload.message.content;
+                        ide.files[path].full_path = reload.message.full_path;
+                        set_editor_content(ide, reload.message.content, reload.message.language);
+                    },
+                });
+            }
+        },
+        error: function (xhr) {
+            const msg = (xhr.responseJSON && xhr.responseJSON._server_messages)
+                ? JSON.parse(xhr.responseJSON._server_messages).map(function (m) {
+                    return JSON.parse(m).message;
+                }).join(' ')
+                : (xhr.message || path);
+            append_terminal($shell, __('Save failed: ') + msg);
+            update_save_button($shell, ide);
+        },
+    });
+}
+
+function update_save_button($shell, ide) {
+    const path = ide.activePath;
+    const dirty = path && ide.files[path] && ide.files[path].dirty;
+    $shell.find('.koda-btn-save').prop('disabled', !dirty);
+}
+
+function update_breadcrumb($shell, rel_path, full_path) {
+    $shell.find('.koda-breadcrumb-path').text(format_display_path(full_path || rel_path || ''));
+}
+
+function load_file_diff(file_path, $shell, ide) {
+    frappe.call({
+        method: 'ampower_koda.agent.api.get_file_diff',
+        args: { request_name: ide.request_name, file_path: file_path },
+        callback: function (r) {
+            const diff = (r.message && r.message.diff) || '';
+            render_diff_panel($shell, diff);
+        },
+    });
+}
+
+function render_diff_panel($shell, diff_text) {
+    const $content = $shell.find('.koda-diff-content').empty();
+    if (!diff_text.trim()) {
+        $content.html(`<div class="koda-empty">${__('No diff for this file.')}</div>`);
+        return;
+    }
+    const parsed = parse_unified_diff(diff_text);
+    const $table = $('<table class="koda-diff-table"><tbody></tbody></table>');
+    const $tbody = $table.find('tbody');
+    parsed.rows.forEach(function (row) {
+        const cls = { add: 'koda-line-add', del: 'koda-line-del', hunk: 'koda-line-hunk' }[row.type] || '';
+        const prefix = row.type === 'add' ? '+' : row.type === 'del' ? '-' : ' ';
+        $tbody.append(`
+            <tr class="${cls}">
+                <td class="koda-line-no">${row.old_no || ''}</td>
+                <td class="koda-line-no">${row.new_no || ''}</td>
+                <td>${prefix}${frappe.utils.escape_html(row.text)}</td>
+            </tr>
+        `);
+    });
+    $content.append($table);
+}
+
+function apply_view_mode($shell, ide) {
+    const $main = $shell.find('.koda-main');
+    $main.removeClass('koda-diff-only');
+    if (ide.viewMode === 'diff') {
+        $main.addClass('koda-diff-only');
+        if (ide.activePath) {
+            load_file_diff(ide.activePath, $shell, ide);
+        }
+    }
+    if (ide.editor) {
+        setTimeout(function () { ide.editor.resize(); }, 50);
+    }
+}
+
+function open_deploy_dialog(ide, $shell) {
+    frappe.call({
+        method: 'ampower_koda.agent.api.get_default_bench_commands',
+        args: { request_name: ide.request_name },
+        callback: function (r) {
+            const cmds = (r.message && r.message.commands) || [];
+            const pending = (ide.context.request && ide.context.request.pending_bench_commands) || [];
+            const list = pending.length ? pending : cmds;
+            const fields = list.map(function (cmd, i) {
+                return {
+                    fieldtype: 'Check',
+                    fieldname: 'cmd_' + i,
+                    label: cmd,
+                    default: 1,
+                };
+            });
+            if (!fields.length) {
+                frappe.msgprint(__('No deploy commands available.'));
+                return;
+            }
+            const dialog = new frappe.ui.Dialog({
+                title: __('Deploy (Bench Commands)'),
+                fields: fields,
+                primary_action_label: __('Run Deploy'),
+                primary_action: function (values) {
+                    const selected = [];
+                    list.forEach(function (cmd, i) {
+                        if (values['cmd_' + i]) selected.push(cmd);
+                    });
+                    if (!selected.length) {
+                        frappe.msgprint(__('Select at least one command.'));
+                        return;
+                    }
+                    dialog.hide();
+                    append_terminal($shell, __('Running deploy commands...'));
+                    frappe.call({
+                        method: 'ampower_koda.agent.api.run_selected_bench_commands',
+                        args: {
+                            request_name: ide.request_name,
+                            commands: JSON.stringify(selected),
+                        },
+                        freeze: true,
+                        callback: function (res) {
+                            append_terminal($shell, (res.message && res.message.log) || __('Deploy finished.'));
+                        },
+                    });
+                },
+            });
+            dialog.show();
+        },
+    });
+}
+
+function open_push_dialog(ide, $shell) {
+    const dialog = new frappe.ui.Dialog({
+        title: __('Commit & Push'),
+        fields: [
+            { fieldname: 'push_branch', fieldtype: 'Check', label: __('Push branch to GitHub'), default: 1 },
+            { fieldname: 'create_pr', fieldtype: 'Check', label: __('Create Pull Request'), default: 1 },
+        ],
+        primary_action_label: __('Run'),
+        primary_action: function (values) {
+            if (!values.push_branch && !values.create_pr) {
+                frappe.msgprint(__('Select at least one action.'));
+                return;
+            }
+            dialog.hide();
+            append_terminal($shell, __('Starting commit and push...'));
+            frappe.call({
+                method: 'ampower_koda.agent.api.ide_push',
+                args: {
+                    request_name: ide.request_name,
+                    push_branch: values.push_branch ? 1 : 0,
+                    create_pr: values.create_pr ? 1 : 0,
+                },
+                freeze: true,
+                callback: function (r) {
+                    append_terminal($shell, (r.message && r.message.message) || __('Push started.'));
+                    frappe.show_alert({ message: __('Push started in background'), indicator: 'blue' });
+                },
+            });
+        },
+    });
+    dialog.show();
+}
+
+function refresh_tree_badges($shell, ide) {
+    frappe.call({
+        method: 'ampower_koda.agent.api.get_change_tree',
+        args: { request_name: ide.request_name },
+        callback: function (r) {
+            if (!r.message) return;
+            ide.context = r.message;
+            render_toolbar_meta($shell, r.message);
+            render_tree($shell, ide, r.message);
+            if (ide.activePath) {
+                $shell.find('.koda-tree-row').filter(function () {
+                    return $(this).attr('data-path') === ide.activePath;
+                }).addClass('selected');
+            }
+        },
+    });
+}
+
+function append_terminal($shell, text) {
+    const $body = $shell.find('.koda-terminal-body');
+    const ts = frappe.datetime.now_datetime();
+    $body.append(`[${ts}] ${text}\n`);
+    $body.scrollTop($body[0].scrollHeight);
+}
+
+function set_status($shell, text, path) {
+    $shell.find('.koda-status-text').text(text);
+    if (path !== undefined) {
+        $shell.find('.koda-status-path').text(format_display_path(path || ''));
+    }
+}
+
+function show_ide_error($shell, message) {
+    $shell.find('.koda-tree').html(`<div class="koda-empty">${frappe.utils.escape_html(message)}</div>`);
+}
+
+function find_first_changed_file(nodes) {
+    for (const node of nodes) {
+        if (node.type === 'file' && node.has_changes) return node;
+        if (node.type === 'folder' && node.children) {
+            const found = find_first_changed_file(node.children);
+            if (found) return found;
+        }
+    }
+    return null;
+}
+
+function parse_unified_diff(diff_text) {
+    const lines = diff_text.split('\n');
+    const rows = [];
+    let old_line = 0;
+    let new_line = 0;
+    for (const raw of lines) {
+        if (raw.startsWith('@@')) {
+            const m = raw.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+            if (m) { old_line = parseInt(m[1], 10); new_line = parseInt(m[2], 10); }
+            rows.push({ type: 'hunk', old_no: '', new_no: '', text: raw });
+            continue;
+        }
+        if (raw.startsWith('+++ ') || raw.startsWith('--- ') || raw.startsWith('diff ')) {
+            rows.push({ type: 'meta', old_no: '', new_no: '', text: raw });
+            continue;
+        }
+        if (raw.startsWith('+')) {
+            rows.push({ type: 'add', old_no: '', new_no: new_line, text: raw.slice(1) });
+            new_line += 1;
+            continue;
+        }
+        if (raw.startsWith('-')) {
+            rows.push({ type: 'del', old_no: old_line, new_no: '', text: raw.slice(1) });
+            old_line += 1;
+            continue;
+        }
+        rows.push({ type: 'ctx', old_no: old_line, new_no: new_line, text: raw.startsWith(' ') ? raw.slice(1) : raw });
+        old_line += 1;
+        new_line += 1;
+    }
+    return { rows: rows };
+}

--- a/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.json
+++ b/ampower_koda/ampower_koda/page/agent_diff_viewer/agent_diff_viewer.json
@@ -1,0 +1,21 @@
+{
+    "content": null,
+    "creation": "2026-07-02 10:00:00.000000",
+    "docstatus": 0,
+    "doctype": "Page",
+    "idx": 0,
+    "modified": "2026-07-02 10:00:00.000000",
+    "modified_by": "Administrator",
+    "module": "Ampower Koda",
+    "name": "agent-diff-viewer",
+    "owner": "Administrator",
+    "page_name": "agent-diff-viewer",
+    "roles": [
+        {
+            "role": "System Manager"
+        }
+    ],
+    "standard": "Yes",
+    "system_page": 0,
+    "title": "Agent IDE"
+}

--- a/ampower_koda/ampower_koda/page/ai_agents_help/ai_agents_help.html
+++ b/ampower_koda/ampower_koda/page/ai_agents_help/ai_agents_help.html
@@ -1,1 +1,0 @@
-<div class="ai-agents-help-page"></div>

--- a/ampower_koda/ampower_koda/page/ai_agents_help/ai_agents_help.js
+++ b/ampower_koda/ampower_koda/page/ai_agents_help/ai_agents_help.js
@@ -19,7 +19,7 @@ frappe.pages['ai-agents-help'].on_page_load = function(wrapper) {
 
         <h3>Getting Started</h3>
         <ol>
-            <li>Open <b>AI Agent Settings</b> from the search bar.</li>
+            <li>Open <b>Agent Settings</b> from the search bar.</li>
             <li>Check <b>Enable AI Agent</b>.</li>
             <li>Enter your API key for OpenAI, Gemini, or Claude.</li>
             <li>Save.</li>
@@ -29,7 +29,7 @@ frappe.pages['ai-agents-help'].on_page_load = function(wrapper) {
 
         <h3>Creating a Request</h3>
         <ol>
-            <li>Go to <a href="/app/ai-agent-request/new">AI Agent Request</a> and click New.</li>
+            <li>Go to <a href="/app/agent-request/new">Agent Request</a> and click New.</li>
             <li>Fill in the Title and Description with what you need.</li>
             <li>Select the AI Provider and Model.</li>
             <li>Enter the Target App Name (e.g. ampower_task_manager).</li>
@@ -110,7 +110,7 @@ frappe.pages['ai-agents-help'].on_page_load = function(wrapper) {
             </tr>
             <tr>
                 <td style="padding:8px;border-bottom:1px solid var(--border-color);">OpenAI</td>
-                <td style="padding:8px;border-bottom:1px solid var(--border-color);">gpt-4o-mini, gpt-4o, gpt-5-mini, o3-mini</td>
+                <td style="padding:8px;border-bottom:1px solid var(--border-color);">gpt-4o-mini, gpt-5-mini, gpt-5.1-codex-mini, gpt-5-codex, gpt-5.1-codex, gpt-5.2-codex</td>
             </tr>
             <tr>
                 <td style="padding:8px;border-bottom:1px solid var(--border-color);">Gemini</td>
@@ -126,7 +126,7 @@ frappe.pages['ai-agents-help'].on_page_load = function(wrapper) {
 
         <h3>Tips</h3>
         <ul>
-            <li>Use a more capable model (gpt-4o, claude-sonnet-4, gemini-2.5-pro) for complex tasks.</li>
+            <li>Use a more capable model (gpt-5.2-codex, claude-sonnet-4, gemini-2.5-pro) for complex tasks.</li>
             <li>Write detailed descriptions -- the more context, the better the result.</li>
             <li>Edit the plan before approving if you see something wrong.</li>
             <li>Test changes on the instance before approving the push.</li>

--- a/ampower_koda/ampower_koda/page/koda_docs/koda_docs.html
+++ b/ampower_koda/ampower_koda/page/koda_docs/koda_docs.html
@@ -1,0 +1,1 @@
+<div class="koda-docs-page"></div>

--- a/ampower_koda/ampower_koda/page/koda_docs/koda_docs.js
+++ b/ampower_koda/ampower_koda/page/koda_docs/koda_docs.js
@@ -1,7 +1,7 @@
-frappe.pages['ai-agents-help'].on_page_load = function(wrapper) {
+frappe.pages['koda-docs'].on_page_load = function(wrapper) {
     var page = frappe.ui.make_app_page({
         parent: wrapper,
-        title: 'AI Agents - How to Use',
+        title: 'Koda Docs - How to Use',
         single_column: true
     });
 
@@ -10,7 +10,7 @@ frappe.pages['ai-agents-help'].on_page_load = function(wrapper) {
 
         <h3>Overview</h3>
         <p>
-            AmPower AI Agents is a coding assistant for Frappe apps.
+            Ampower Koda is a coding assistant for Frappe apps.
             You describe a bug fix, feature, or improvement -- the agent reads the target app,
             creates a plan, implements the changes, and opens a pull request on GitHub.
         </p>
@@ -147,7 +147,7 @@ frappe.pages['ai-agents-help'].on_page_load = function(wrapper) {
         <hr>
 
         <p style="color:var(--text-muted);font-size:12px;">
-            AmPower AI Agents by Ambibuzz Technologies LLP.
+            Ampower Koda by Ambibuzz Technologies LLP.
             For issues, contact buzz@ambibuzz.com.
         </p>
     </div>

--- a/ampower_koda/ampower_koda/page/koda_docs/koda_docs.json
+++ b/ampower_koda/ampower_koda/page/koda_docs/koda_docs.json
@@ -1,15 +1,15 @@
 {
     "content": null,
-    "creation": "2026-07-02 10:00:00.000000",
+    "creation": "2026-03-12 10:00:00.000000",
     "docstatus": 0,
     "doctype": "Page",
     "idx": 0,
-    "modified": "2026-07-02 10:00:00.000000",
+    "modified": "2026-03-12 10:00:00.000000",
     "modified_by": "Administrator",
     "module": "Ampower Koda",
-    "name": "agent-diff-viewer",
+    "name": "koda-docs",
     "owner": "Administrator",
-    "page_name": "agent-diff-viewer",
+    "page_name": "koda-docs",
     "roles": [
         {
             "role": "System Manager"
@@ -17,5 +17,5 @@
     ],
     "standard": "Yes",
     "system_page": 0,
-    "title": "Agent IDE"
+    "title": "Koda Docs"
 }

--- a/ampower_koda/ampower_koda/page/koda_ide/koda_ide.html
+++ b/ampower_koda/ampower_koda/page/koda_ide/koda_ide.html
@@ -1,0 +1,1 @@
+<div class="koda-ide-page"></div>

--- a/ampower_koda/ampower_koda/page/koda_ide/koda_ide.js
+++ b/ampower_koda/ampower_koda/page/koda_ide/koda_ide.js
@@ -1,12 +1,12 @@
 /* global ace */
 
-frappe.pages['agent-diff-viewer'].on_page_load = function (wrapper) {
+frappe.pages['koda-ide'].on_page_load = function (wrapper) {
     const route = frappe.get_route();
     const request_name = route[1];
 
     const page = frappe.ui.make_app_page({
         parent: wrapper,
-        title: __('Agent IDE'),
+        title: __('Koda IDE'),
         single_column: true,
     });
 
@@ -438,7 +438,7 @@ function build_ide_shell(page, ide) {
     const $shell = $(`
         <div class="koda-ide">
             <div class="koda-toolbar">
-                <span class="koda-title">${__('Agent IDE')}</span>
+                <span class="koda-title">${__('Koda IDE')}</span>
                 <span class="koda-meta koda-toolbar-meta">${__('Loading...')}</span>
                 <div class="koda-toolbar-actions">
                     <button type="button" class="koda-btn koda-btn-primary koda-btn-save" disabled title="Ctrl+S">${__('Save')}</button>

--- a/ampower_koda/ampower_koda/page/koda_ide/koda_ide.js
+++ b/ampower_koda/ampower_koda/page/koda_ide/koda_ide.js
@@ -176,6 +176,10 @@ function inject_ide_styles() {
             white-space: nowrap;
         }
         .koda-toolbar .koda-meta b { color: var(--text); font-weight: 600; }
+        .koda-branch-warning {
+            color: #e3a008;
+            font-weight: 600;
+        }
         .koda-toolbar-actions {
             display: flex;
             align-items: center;
@@ -619,7 +623,7 @@ function load_workspace(request_name, $shell, ide) {
             }
             ide.context = r.message;
             ide.treeData = r.message.tree;
-            render_toolbar_meta($shell, r.message);
+            render_toolbar_meta($shell, ide, r.message);
             render_tree($shell, ide, r.message);
             const first = find_first_changed_file(r.message.tree || []);
             if (first) {
@@ -629,16 +633,60 @@ function load_workspace(request_name, $shell, ide) {
     });
 }
 
-function render_toolbar_meta($shell, data) {
+function render_toolbar_meta($shell, ide, data) {
     const branch = data.branch_name || '—';
     const count = (data.totals && data.totals.files) || Object.keys(data.changed || {}).length;
     const status = (data.request && data.request.status) || '';
-    $shell.find('.koda-toolbar-meta').html(
-        `${frappe.utils.escape_html(data.app_name || '')} · `
+    let html = `${frappe.utils.escape_html(data.app_name || '')} · `
         + `${count} ${__('changed')} · `
         + `${__('branch')}: <b>${frappe.utils.escape_html(branch)}</b> · `
-        + `${__('status')}: ${frappe.utils.escape_html(status)}`
-    );
+        + `${__('status')}: ${frappe.utils.escape_html(status)}`;
+    if (data.branch_matches === false) {
+        const on = frappe.utils.escape_html(data.current_branch || __('(unknown)'));
+        html += ` · <span class="koda-branch-warning">${__('Read-only — repo is on {0}', [on])}</span>`;
+    }
+    $shell.find('.koda-toolbar-meta').html(html);
+    apply_branch_state($shell, ide, data);
+}
+
+function apply_branch_state($shell, ide, data) {
+    // branch_matches is only present on newer backends; absence means editable.
+    const readOnly = data.branch_matches === false;
+    const was_read_only = ide.readOnly === true;
+    ide.readOnly = readOnly;
+    ide.current_branch = data.current_branch || '';
+    ide.branch_name = data.branch_name || '';
+
+    const $save = $shell.find('.koda-btn-save');
+    const $deploy = $shell.find('.koda-btn-deploy');
+    const $push = $shell.find('.koda-btn-push');
+    const $codeBtn = $shell.find('.koda-view-btn[data-mode="code"]');
+
+    if (readOnly) {
+        const tip = __('Repository is on branch {0}, not {1}. Checkout {1} to edit, deploy, or push.',
+            [ide.current_branch || __('(unknown)'), ide.branch_name || __('(none)')]);
+        $save.prop('disabled', true).attr('title', tip);
+        $deploy.prop('disabled', true).attr('title', tip);
+        $push.prop('disabled', true).attr('title', tip);
+        $codeBtn.prop('disabled', true).attr('title', tip);
+        if (ide.editor) ide.editor.setReadOnly(true);
+
+        // Force diff-only view since the working tree is not this request's branch.
+        ide.viewMode = 'diff';
+        $shell.find('.koda-view-btn').removeClass('active');
+        $shell.find('.koda-view-btn[data-mode="diff"]').addClass('active');
+        apply_view_mode($shell, ide);
+
+        if (!was_read_only) {
+            append_terminal($shell, tip);
+        }
+    } else {
+        $deploy.prop('disabled', false).attr('title', '');
+        $push.prop('disabled', false).attr('title', '');
+        $codeBtn.prop('disabled', false).attr('title', '');
+        if (ide.editor) ide.editor.setReadOnly(false);
+        update_save_button($shell, ide);
+    }
 }
 
 function render_tree($shell, ide, data) {
@@ -726,6 +774,16 @@ function do_open_file(file_path, $shell, ide) {
     $shell.find('.koda-tree-row').filter(function () {
         return $(this).attr('data-path') === file_path;
     }).addClass('selected');
+
+    if (ide.readOnly) {
+        // Working tree is on a different branch; show the diff only, never read the file.
+        $shell.find('.koda-editor-wrap').addClass('has-file');
+        update_breadcrumb($shell, file_path, file_path);
+        update_tabs($shell, ide);
+        set_status($shell, file_path, file_path);
+        load_file_diff(file_path, $shell, ide);
+        return;
+    }
 
     const loadAndShow = function (content, language, full_path) {
         ide.files[file_path] = ide.files[file_path] || {};
@@ -1037,7 +1095,6 @@ function open_push_dialog(ide, $shell) {
                 return;
             }
             dialog.hide();
-            append_terminal($shell, __('Starting commit and push...'));
             frappe.call({
                 method: 'ampower_koda.agent.api.ide_push',
                 args: {
@@ -1047,7 +1104,14 @@ function open_push_dialog(ide, $shell) {
                 },
                 freeze: true,
                 callback: function (r) {
-                    append_terminal($shell, (r.message && r.message.message) || __('Push started.'));
+                    const msg = (r.message && r.message.message) || '';
+                    if (r.message && r.message.status === 'noop') {
+                        append_terminal($shell, msg || __('No changes to push.'));
+                        frappe.show_alert({ message: msg || __('No changes to push.'), indicator: 'orange' });
+                        return;
+                    }
+                    append_terminal($shell, __('Starting commit and push...'));
+                    append_terminal($shell, msg || __('Push started.'));
                     frappe.show_alert({ message: __('Push started in background'), indicator: 'blue' });
                 },
             });
@@ -1063,7 +1127,7 @@ function refresh_tree_badges($shell, ide) {
         callback: function (r) {
             if (!r.message) return;
             ide.context = r.message;
-            render_toolbar_meta($shell, r.message);
+            render_toolbar_meta($shell, ide, r.message);
             render_tree($shell, ide, r.message);
             if (ide.activePath) {
                 $shell.find('.koda-tree-row').filter(function () {

--- a/ampower_koda/ampower_koda/page/koda_ide/koda_ide.json
+++ b/ampower_koda/ampower_koda/page/koda_ide/koda_ide.json
@@ -1,15 +1,15 @@
 {
     "content": null,
-    "creation": "2026-03-12 10:00:00.000000",
+    "creation": "2026-07-02 10:00:00.000000",
     "docstatus": 0,
     "doctype": "Page",
     "idx": 0,
-    "modified": "2026-03-12 10:00:00.000000",
+    "modified": "2026-07-02 10:00:00.000000",
     "modified_by": "Administrator",
     "module": "Ampower Koda",
-    "name": "ai-agents-help",
+    "name": "koda-ide",
     "owner": "Administrator",
-    "page_name": "ai-agents-help",
+    "page_name": "koda-ide",
     "roles": [
         {
             "role": "System Manager"
@@ -17,5 +17,5 @@
     ],
     "standard": "Yes",
     "system_page": 0,
-    "title": "AI Agents Help"
+    "title": "Koda IDE"
 }

--- a/ampower_koda/ampower_koda/workspace/ai_agents/ai_agents.json
+++ b/ampower_koda/ampower_koda/workspace/ai_agents/ai_agents.json
@@ -1,6 +1,6 @@
 {
     "charts": [],
-    "content": "[{\"id\":\"shortcut-section\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"AI Agents Help\",\"col\":12}},{\"id\":\"shortcut-section-2\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Agent Request\",\"col\":12}},{\"id\":\"shortcut-section-3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Agent Settings\",\"col\":12}}]",
+    "content": "[{\"id\":\"shortcut-section\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Koda Docs\",\"col\":12}},{\"id\":\"shortcut-section-2\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Agent Request\",\"col\":12}},{\"id\":\"shortcut-section-3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Agent Settings\",\"col\":12}}]",
     "creation": "2026-03-05 12:00:00.000000",
     "custom_blocks": [],
     "docstatus": 0,
@@ -15,9 +15,9 @@
         {
             "hidden": 0,
             "is_query_report": 0,
-            "label": "AI Agents Help",
+            "label": "Koda Docs",
             "link_count": 0,
-            "link_to": "ai-agents-help",
+            "link_to": "koda-docs",
             "link_type": "Page",
             "onboard": 1,
             "type": "Link"
@@ -58,8 +58,8 @@
         {
             "color": "Blue",
             "doc_view": "",
-            "label": "AI Agents Help",
-            "link_to": "ai-agents-help",
+            "label": "Koda Docs",
+            "link_to": "koda-docs",
             "stats_filter": "",
             "type": "Page"
         },

--- a/ampower_koda/ampower_koda/workspace/ai_agents/ai_agents.json
+++ b/ampower_koda/ampower_koda/workspace/ai_agents/ai_agents.json
@@ -1,6 +1,6 @@
 {
     "charts": [],
-    "content": "[{\"id\":\"shortcut-section\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"AI Agents Help\",\"col\":12}},{\"id\":\"shortcut-section-2\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"AI Agent Request\",\"col\":12}},{\"id\":\"shortcut-section-3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"AI Agent Settings\",\"col\":12}}]",
+    "content": "[{\"id\":\"shortcut-section\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"AI Agents Help\",\"col\":12}},{\"id\":\"shortcut-section-2\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Agent Request\",\"col\":12}},{\"id\":\"shortcut-section-3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Agent Settings\",\"col\":12}}]",
     "creation": "2026-03-05 12:00:00.000000",
     "custom_blocks": [],
     "docstatus": 0,
@@ -25,9 +25,9 @@
         {
             "hidden": 0,
             "is_query_report": 0,
-            "label": "AI Agent Request",
+            "label": "Agent Request",
             "link_count": 0,
-            "link_to": "AI Agent Request",
+            "link_to": "Agent Request",
             "link_type": "DocType",
             "onboard": 0,
             "type": "Link"
@@ -35,15 +35,15 @@
         {
             "hidden": 0,
             "is_query_report": 0,
-            "label": "Settings",
+            "label": "Agent Settings",
             "link_count": 0,
-            "link_to": "AI Agent Settings",
+            "link_to": "Agent Settings",
             "link_type": "DocType",
             "onboard": 0,
             "type": "Link"
         }
     ],
-    "modified": "2026-05-14 12:05:00.000000",
+    "modified": "2026-07-02 12:00:00.000000",
     "modified_by": "Administrator",
     "module": "Ampower Koda",
     "name": "AI Agents",
@@ -66,16 +66,16 @@
         {
             "color": "Grey",
             "doc_view": "List",
-            "label": "AI Agent Request",
-            "link_to": "AI Agent Request",
+            "label": "Agent Request",
+            "link_to": "Agent Request",
             "stats_filter": "",
             "type": "DocType"
         },
         {
             "color": "Grey",
             "doc_view": "",
-            "label": "AI Agent Settings",
-            "link_to": "AI Agent Settings",
+            "label": "Agent Settings",
+            "link_to": "Agent Settings",
             "stats_filter": "",
             "type": "DocType"
         }

--- a/ampower_koda/hooks.py
+++ b/ampower_koda/hooks.py
@@ -7,6 +7,6 @@ app_license = "MIT"
 required_apps = ["frappe"]
 
 doctype_js = {
-    "AI Agent Request": "ampower_koda/doctype/ai_agent_request/ai_agent_request.js",
-    "AI Agent Settings": "ampower_koda/doctype/ai_agent_settings/ai_agent_settings.js",
+    "Agent Request": "ampower_koda/doctype/agent_request/agent_request.js",
+    "Agent Settings": "ampower_koda/doctype/agent_settings/agent_settings.js",
 }

--- a/ampower_koda/hooks.py
+++ b/ampower_koda/hooks.py
@@ -1,5 +1,5 @@
 app_name = "ampower_koda"
-app_title = "AmPower Koda"
+app_title = "Ampower Koda"
 app_publisher = "Ambibuzz Technologies LLP"
 app_description = "AI Coding Agent for Frappe apps"
 app_email = "buzz@ambibuzz.com"

--- a/ampower_koda/patches.txt
+++ b/ampower_koda/patches.txt
@@ -1,3 +1,4 @@
 [pre_model_sync]
 
 [post_model_sync]
+ampower_koda.patches.rename_agent_doctypes

--- a/ampower_koda/patches/rename_agent_doctypes.py
+++ b/ampower_koda/patches/rename_agent_doctypes.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, Ambibuzz Technologies LLP and contributors
+import frappe
+
+
+RENAME_MAP = [
+    ("AI Agent Prompt Configuration", "Agent Prompt Configuration"),
+    ("AI Agent Settings", "Agent Settings"),
+    ("AI Agent Request", "Agent Request"),
+]
+
+
+def execute():
+    """Rename legacy AI Agent DocTypes to shorter names."""
+    for old_name, new_name in RENAME_MAP:
+        if not frappe.db.exists("DocType", old_name):
+            continue
+        if frappe.db.exists("DocType", new_name):
+            continue
+        frappe.rename_doc("DocType", old_name, new_name, force=True)
+
+    _migrate_user_settings()
+    frappe.db.commit()
+
+
+def _migrate_user_settings():
+    """Copy per-user form settings from old DocType name to new."""
+    rows = frappe.db.sql(
+        """SELECT `user`, `data` FROM `__UserSettings`
+        WHERE doctype = %s""",
+        "AI Agent Request",
+        as_dict=True,
+    )
+    for row in rows:
+        exists = frappe.db.exists(
+            "__UserSettings",
+            {"user": row.user, "doctype": "Agent Request"},
+        )
+        if exists:
+            continue
+        frappe.db.sql(
+            """INSERT INTO `__UserSettings` (`user`, `doctype`, `data`)
+            VALUES (%s, %s, %s)""",
+            (row.user, "Agent Request", row.data),
+        )
+        frappe.cache.hdel("_user_settings", f"Agent Request::{row.user}")

--- a/koda.md
+++ b/koda.md
@@ -1,0 +1,144 @@
+# KODA.md
+
+Frappe-specific behavioral skills for **AmPower Koda**. Koda works on any Frappe app task — bug fixes, new features, improvements, DocTypes, Script Reports, Pages, hooks, APIs, client scripts, and bench workflows.
+
+**Tradeoff:** These skills bias toward caution over speed. For trivial one-line fixes, use judgment.
+
+---
+
+## Task types Koda handles
+
+| Type | Examples | Typical files |
+|------|----------|---------------|
+| **Bug Fix** | Wrong validation, broken API, JS error, bad query | `.py`, `.js`, `hooks.py` — often one file |
+| **Feature Request** | New DocType, Report, Page, workflow, integration | `.json`, `.py`, `.js`, `hooks.py` |
+| **Improvement** | UX tweak, performance, refactor within scope | `.js`, `.py`, `.css`, `.html` |
+
+Match exploration and edits to the **request type** — don't default to DocType JSON + migrate for every task.
+
+---
+
+## 1. Think Before Coding
+
+**Don't assume. Surface Frappe tradeoffs for THIS task.**
+
+Before implementing:
+- Identify the task type (bug fix / feature / improvement) and which artifact is involved (DocType, Report, Page, hook, API, client script).
+- For **bug fixes**: locate the failing path first (error message → controller → client → hook) before changing anything.
+- For **new artifacts**: find a similar Report, Page, or DocType in the app and copy its pattern.
+- If multiple valid approaches exist (client script vs server validation vs Property Setter), present them — don't pick silently.
+- NEVER guess `fieldname`, report columns, API method paths, or hook keys — read the actual files.
+
+---
+
+## 2. Simplicity First
+
+**Minimum Frappe code for the requested task. Nothing speculative.**
+
+- Bug fix: smallest change that fixes the root cause — no refactors.
+- New feature: only the files the feature needs (a Report may be `.json` + `.py` + `.js`; a bug may be one line in `.py`).
+- No extra DocTypes, reports, or APIs beyond what was asked.
+- No custom SQL when `frappe.get_all` / `frappe.db.get_value` is enough.
+- Copy how the same app already solves a similar problem.
+
+---
+
+## 3. Surgical Changes
+
+**Touch only files the task requires.**
+
+- Bug fix in a controller → don't rewrite the client script unless the bug is there.
+- New Report → don't modify unrelated DocTypes.
+- Match existing style: 4-space Python, tab JSON, existing `frappe.call` patterns.
+- Remove only imports your change made unused.
+
+---
+
+## 4. Goal-Driven Execution
+
+**Define success criteria for the specific task.**
+
+| Task | Verify |
+|------|--------|
+| Bug fix | Original failure path resolved; `validate_code` passes; no regression |
+| New DocType | `.json` valid, migrate succeeds, form loads |
+| Script Report | Report JSON + `execute`/`get_columns` in `.py`; report runs in desk |
+| Custom Page | Page loads, `frappe.pages` or route works, data fetches |
+| New API | `@frappe.whitelist()` + `frappe.call` path match |
+| Hook / event | Event fires at correct lifecycle; no duplicate hook keys |
+| UI improvement | Client behavior matches request; build if assets changed |
+
+In review: check **user request scope** and blocking bugs — not an exhaustive JSON metadata audit.
+
+---
+
+## Absolute Rules (Frappe)
+
+1. NEVER guess field names, report config, or API paths — read `.json`, `read_doctype_schema`, or `read_file` first.
+2. NEVER fabricate paths, method names, or module names not seen in the codebase.
+3. NEVER create a new standard artifact without reading an existing one of the **same type** in the app.
+4. NEVER guess file contents — `read_file` before every edit.
+5. After every `.py`/`.js` edit: `validate_code`, then `read_file` the edited region.
+6. NEVER insert code inside JS template literals or wrong scope.
+7. `frappe.call` method path must match `@frappe.whitelist()` location when client↔server is involved.
+
+---
+
+## Frappe Exploration Skill
+
+Explore based on **what the user asked for**:
+
+**Any task**
+1. `find_files()` — map `doctype/`, `report/`, `page/`, `public/`, `patches/`, `hooks.py`
+2. `read_file("hooks.py")` — events, schedulers, assets, overrides
+
+**Bug fix**
+3. `search_code` for error text, function names, fieldnames from the description
+4. Trace UI → `frappe.call` → Python → DB query end-to-end
+5. Read only files on the failure path plus one similar working example
+
+**New DocType / field**
+3. `read_doctype_schema` + read `.json`, `.py`, `.js` together
+
+**New Report**
+3. Read an existing Script Report in the app: `.json`, `.py`, `.js`
+4. Note `ref_doctype`, `report_type`, `execute` / column definitions
+
+**New Page / feature**
+3. Read similar page or feature: `.json`, `.py`, `.js`, `.html`
+4. Trace how data is loaded and rendered
+
+**API / server logic**
+3. `search_code("@frappe.whitelist")` and `frappe.call` in client files
+
+---
+
+## Frappe Editing Skill
+
+**Read → Anchor → Edit → Validate → Verify**
+
+| Artifact | Files | Notes |
+|----------|-------|-------|
+| Bug fix | Usually `.py` or `.js` | Fix root cause only; read surrounding logic |
+| DocType | `.json`, `.py`, `.js` | Schema first if fields change; then migrate |
+| Script Report | `.json`, `.py`, `.js` | Copy peer report structure; `execute` returns columns/data |
+| Page | `.json`, `.py`, `.js`, `.html` | `frappe.pages` or desk page pattern |
+| API only | `.py` (+ `.js` if wired) | `@frappe.whitelist()` decorator and path |
+| Hook / event | `hooks.py`, controller `.py` | Append to dicts; no duplicate keys |
+| Patch | `patches.txt`, patch `.py` | `[post_model_sync]` for schema/data |
+| Assets | `public/js`, `public/css` | `bench build` after changes |
+
+Prefer `replace_lines`. DocType JSON → migrate. JS/CSS/HTML → build.
+
+---
+
+## Frappe Review Skill
+
+Review only what the user asked for.
+
+- **Bug fix**: fix addresses the reported issue; no unrelated edits.
+- **Report**: report files present and consistent; no DocType audit unless requested.
+- **Feature**: scope matches request; syntax valid; wiring correct if client↔server.
+- Fail only for blocking bugs — max 5 issues. No field-by-field JSON metadata audits.
+
+---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langchain-core>=0.3.0",
     "langchain-google-genai>=2.0.0",
     "langchain-anthropic>=0.3.0",
+    "rapidfuzz>=2.15.0,<3",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "langchain-core>=0.3.0",
     "langchain-google-genai>=2.0.0",
     "langchain-anthropic>=0.3.0",
-    "rapidfuzz>=2.15.0,<3",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

This PR is a major upgrade to Ampower Koda covering the in-browser IDE, agent execution reliability, cleaner UX/logs, token optimization, and patch-only follow-ups.

### Highlights

- **Koda IDE** (`koda-ide`):  full in-browser editor with file explorer, diff view, save/deploy/push, light/dark theme, and branch-aware read-only mode when the checkout doesn’t match the request branch
- **Renamed DocTypes & pages**:  `AI Agent Request` → `Agent Request`, `AI Agent Settings` → `Agent Settings`; help page → `koda-docs`; diff viewer --> `koda-ide`
- **Bounded test/review stage** — fast Frappe-standards review (syntax pre-check, capped tool rounds, auto-retry implement on failure)
- **Patch-only follow-ups**:  fix bugs on the same branch without re-implementing or replacing the approved plan
- **Token optimization**:  prompt caching, history trimming, full human-readable `conversation_log`
- **Reliability hardening** :  write-nudge to prevent read-only loops, syntax auto-fix, scratch-file stripping, content-based change detection for follow-ups
- **Cleaner operator experience** : `change_summary` field, graceful no-changes push, improved logs, centralized error logging to Frappe Error Log
