### PR TITLE
fix: real mechanical review checks + structured verdict parsing

### DIFF
--- a/ampower_koda/agent/checks.py
+++ b/ampower_koda/agent/checks.py
@@ -1,0 +1,358 @@
+"""Real, mechanical Frappe health checks — run before any LLM review.
+
+Four checks, each independent and each returning a plain pass/fail plus a
+short human-readable reason. If every check passes, review_node decides
+whether the change is small/safe enough to skip the LLM call too — see
+``needs_llm_review`` below.
+
+This module never raises on a single bad file — one broken edit should not
+crash the whole check pass. Every checker catches its own exceptions and
+reports them as a failure line instead.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import subprocess
+
+import frappe
+
+from ampower_koda.agent.tools import _resolve_path, validate_code
+from ampower_koda.agent.git_ops import diff_file
+
+REQUIRED_DOCTYPE_KEYS = ("doctype", "name", "module")
+REQUIRED_REPORT_KEYS = ("doctype", "report_name", "ref_doctype")
+REQUIRED_PAGE_KEYS = ("doctype", "page_name")
+
+# Which required-key set applies, keyed by the JSON's own "doctype" value —
+# this is the same field Frappe itself uses to know what kind of record it is.
+_REQUIRED_KEYS_BY_DOCTYPE = {
+    "DocType": REQUIRED_DOCTYPE_KEYS,
+    "Report": REQUIRED_REPORT_KEYS,
+    "Page": REQUIRED_PAGE_KEYS,
+}
+
+
+class CheckResult:
+    """One check's verdict: did it pass, and what should a human/LLM read."""
+
+    __slots__ = ("name", "passed", "detail")
+
+    def __init__(self, name: str, passed: bool, detail: str = ""):
+        self.name = name
+        self.passed = passed
+        self.detail = detail
+
+    def line(self) -> str:
+        status = "OK" if self.passed else "FAIL"
+        return f"[{status}] {self.name}: {self.detail}" if self.detail else f"[{status}] {self.name}"
+
+
+class HealthReport:
+    """The combined result of every check run for one review pass."""
+
+    def __init__(self, results: list[CheckResult]):
+        self.results = results
+
+    @property
+    def passed(self) -> bool:
+        return all(r.passed for r in self.results)
+
+    @property
+    def failures(self) -> list[CheckResult]:
+        return [r for r in self.results if not r.passed]
+
+    def summary(self, limit: int = 12) -> str:
+        """Readable report — failures first, so a human/LLM sees them without scrolling."""
+        ordered = self.failures + [r for r in self.results if r.passed]
+        lines = [r.line() for r in ordered[:limit]]
+        if len(ordered) > limit:
+            lines.append(f"... and {len(ordered) - limit} more check(s).")
+        return "\n".join(lines)
+
+
+def run_health_checks(app_name: str, edits: list[dict]) -> HealthReport:
+    """Run every mechanical check against this run's edited files."""
+    paths = [e.get("path", "") for e in (edits or []) if e.get("path")]
+    results: list[CheckResult] = []
+    results.extend(_syntax_checks(app_name, paths))
+    results.extend(_json_checks(app_name, paths))
+    results.extend(_import_checks(app_name, paths))
+    results.extend(_wiring_checks(app_name, paths))
+    return HealthReport(results)
+
+
+# ---------------------------------------------------------------------------
+# Syntax — thin wrapper over the existing validate_code tool
+# ---------------------------------------------------------------------------
+
+def _syntax_checks(app_name: str, paths: list[str]) -> list[CheckResult]:
+    results = []
+    for path in paths:
+        if not path.endswith((".py", ".js")):
+            continue
+        outcome = validate_code(app_name, path)
+        if "Not a file" in outcome:
+            # A phantom path parsed from the model's own summary text, not a
+            # real edit — nothing to check.
+            continue
+        ok = outcome.startswith("VALID")
+        results.append(CheckResult(f"syntax:{path}", ok, outcome.split("\n", 1)[0][:200]))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# DocType / Report / Page JSON
+# ---------------------------------------------------------------------------
+
+def _json_checks(app_name: str, paths: list[str]) -> list[CheckResult]:
+    results = []
+    for path in paths:
+        if not path.endswith(".json"):
+            continue
+        try:
+            full = _resolve_path(app_name, path)
+        except ValueError as e:
+            results.append(CheckResult(f"json:{path}", False, str(e)))
+            continue
+        if not os.path.isfile(full):
+            continue
+
+        try:
+            with open(full, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            results.append(CheckResult(f"json:{path}", False, f"invalid JSON: {e}"))
+            continue
+
+        if not isinstance(data, dict) or "doctype" not in data:
+            # Not a Frappe metadata file (e.g. a plain config/data JSON) —
+            # valid JSON is all that's expected of it.
+            results.append(CheckResult(f"json:{path}", True))
+            continue
+
+        required = _REQUIRED_KEYS_BY_DOCTYPE.get(data["doctype"])
+        if required is None:
+            # A DocType/Report/Page JSON of a kind we don't have a specific
+            # rule for yet — valid JSON with a doctype key is as far as we check.
+            results.append(CheckResult(f"json:{path}", True))
+            continue
+
+        missing = [key for key in required if not data.get(key)]
+        if missing:
+            results.append(CheckResult(f"json:{path}", False, f"missing required key(s): {', '.join(missing)}"))
+        else:
+            results.append(CheckResult(f"json:{path}", True))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Import smoke test — run in a subprocess so a broken import can't take
+# down the checker process itself, and so partially-applied module state
+# from one bad import never leaks into the next check.
+# ---------------------------------------------------------------------------
+
+def _import_checks(app_name: str, paths: list[str]) -> list[CheckResult]:
+    results = []
+    for path in paths:
+        if not path.endswith(".py") or path.endswith("__init__.py"):
+            continue
+        try:
+            full = _resolve_path(app_name, path)
+        except ValueError as e:
+            results.append(CheckResult(f"import:{path}", False, str(e)))
+            continue
+        if not os.path.isfile(full):
+            continue
+
+        module_name = _module_name_for(app_name, path)
+        if module_name is None:
+            continue
+
+        proc = subprocess.run(
+            ["python3", "-c", f"import {module_name}"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=frappe.get_bench_path() if hasattr(frappe, "get_bench_path") else None,
+        )
+        if proc.returncode == 0:
+            results.append(CheckResult(f"import:{path}", True))
+        else:
+            failure = (proc.stderr or proc.stdout).strip().splitlines()
+            last_line = failure[-1] if failure else "import failed"
+            results.append(CheckResult(f"import:{path}", False, last_line[:200]))
+    return results
+
+
+def _module_name_for(app_name: str, relative_path: str) -> str | None:
+    """Turn ``app/module/file.py`` into ``app.module.file`` for ``import``."""
+    if not relative_path.endswith(".py"):
+        return None
+    without_ext = relative_path[: -len(".py")]
+    parts = [p for p in without_ext.split("/") if p]
+    if not parts:
+        return None
+    return ".".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Client <-> server wiring — every frappe.call({method: "..."}) in edited JS
+# must resolve to a real, @frappe.whitelist()-decorated Python function.
+# ---------------------------------------------------------------------------
+
+_CALL_METHOD_RE = None  # compiled lazily to keep the import list minimal
+
+
+def _wiring_checks(app_name: str, paths: list[str]) -> list[CheckResult]:
+    global _CALL_METHOD_RE
+    if _CALL_METHOD_RE is None:
+        _CALL_METHOD_RE = re.compile(r"""frappe\.call\(\s*\{[^}]*?method\s*:\s*["']([\w.]+)["']""")
+
+    results = []
+    for path in paths:
+        if not path.endswith(".js"):
+            continue
+        try:
+            full = _resolve_path(app_name, path)
+        except ValueError as e:
+            results.append(CheckResult(f"wiring:{path}", False, str(e)))
+            continue
+        if not os.path.isfile(full):
+            continue
+
+        with open(full, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+
+        methods = _CALL_METHOD_RE.findall(content)
+        if not methods:
+            continue
+
+        for method in methods:
+            ok, reason = _whitelisted(method)
+            results.append(CheckResult(f"wiring:{path} -> {method}", ok, reason))
+    return results
+
+
+def _whitelisted(dotted_method: str) -> tuple[bool, str]:
+    """Confirm ``dotted_method`` exists and is @frappe.whitelist()-decorated."""
+    try:
+        module_name, _, func_name = dotted_method.rpartition(".")
+        if not module_name:
+            return False, "not a fully-qualified method path"
+        module = frappe.get_attr(module_name) if hasattr(frappe, "get_attr") else __import__(module_name, fromlist=["_"])
+        func = getattr(module, func_name, None)
+        if func is None:
+            return False, "method not found"
+        if not getattr(func, "whitelisted", False):
+            return False, "found but not @frappe.whitelist()"
+        return True, ""
+    except Exception as e:  # a bad import here is itself a wiring failure, not a crash
+        return False, f"could not resolve: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Deciding whether the mechanical checks passing is enough on its own, or
+# whether this specific change is worth an LLM's judgment too.
+#
+# Two independent, cheap-to-compute signals — neither needs a model call:
+#   1. size    — how many lines actually changed, from the real git diff
+#   2. risk    — does the diff touch anything on a fixed watch-list
+#
+# Either one alone is enough to force an LLM pass. The default is to SKIP,
+# so token savings only happen when both signals agree there's nothing here
+# worth a model's attention.
+# ---------------------------------------------------------------------------
+
+# Deliberately small and specific — a long list of vague terms just forces
+# the LLM pass on everything, which defeats the point of having this at all.
+# Checked only against ADDED lines in the diff (see needs_llm_review below) —
+# matching the whole unified diff would also catch unrelated code sitting in
+# the surrounding context lines, which would force LLM review on any edit
+# that merely lands near, say, an existing subprocess.run() call.
+RISK_PATTERNS = (
+    re.compile(r"\bfrappe\.db\.sql\b"),
+    re.compile(r"\bdelete_doc\b"),
+    re.compile(r"\bos\.system\b"),
+    re.compile(r"\bsubprocess\."),
+    re.compile(r"\beval\("),
+    re.compile(r"\bexec\("),
+    re.compile(r"\bignore_permissions\s*=\s*True\b"),
+    re.compile(r"\bhas_permission\b"),
+    re.compile(r"\bfrappe\.session\.user\b"),
+    re.compile(r"\bapi_key\b", re.IGNORECASE),
+    re.compile(r"\bsecret\b", re.IGNORECASE),
+    re.compile(r"\bpassword\b", re.IGNORECASE),
+    re.compile(r"@frappe\.whitelist\([^)]*allow_guest\s*=\s*True"),
+)
+
+# Changes at or under this many total changed lines (added + removed, from
+# the real diff) are treated as small enough that a passed mechanical check
+# is sufficient on its own.
+SMALL_CHANGE_LINE_THRESHOLD = 25
+
+
+class ReviewDecision:
+    """Whether this run's edits need an LLM look, and why."""
+
+    __slots__ = ("needs_llm", "reason")
+
+    def __init__(self, needs_llm: bool, reason: str):
+        self.needs_llm = needs_llm
+        self.reason = reason
+
+
+def needs_llm_review(app_name: str, base_branch: str, branch_name: str, edits: list[dict]) -> ReviewDecision:
+    """Decide whether mechanical checks passing is enough, or an LLM should
+    still look at this change.
+
+    Only ``.py`` edits are considered for size/risk — pure JSON/JS-only
+    changes are already fully covered by the mechanical checks (JSON
+    validity + the wiring check), so they never need this at all.
+    """
+    py_paths = [e.get("path", "") for e in (edits or []) if (e.get("path") or "").endswith(".py")]
+    if not py_paths:
+        return ReviewDecision(False, "no Python changes — mechanical checks cover this fully")
+
+    if not branch_name:
+        # No branch to diff against yet (e.g. edits not committed) — cannot
+        # measure size/risk safely, so fail toward the LLM rather than
+        # silently skipping a change we couldn't actually inspect.
+        return ReviewDecision(True, "no branch available to diff — cannot assess size/risk")
+
+    total_changed_lines = 0
+    for path in py_paths:
+        ok, diff_text = diff_file(app_name, base_branch, branch_name, path)
+        if not ok:
+            # Can't get a diff for this file — same reasoning as above,
+            # don't guess that it's safe.
+            return ReviewDecision(True, f"could not diff {path} — cannot assess size/risk")
+
+        for line in diff_text.splitlines():
+            if line.startswith(("+++", "---")):
+                continue
+            if line.startswith(("+", "-")):
+                total_changed_lines += 1
+
+        # Outside the line-counting loop on purpose — only needs to be built
+        # once per file, and must run even when the diff has zero +/- lines
+        # (e.g. a rename-only change), so it can never be left unassigned.
+        added_lines = "\n".join(
+            line[1:] for line in diff_text.splitlines()
+            if line.startswith("+") and not line.startswith("+++")
+        )
+        for pattern in RISK_PATTERNS:
+            if pattern.search(added_lines):
+                return ReviewDecision(True, f"{path} matches a risk pattern ({pattern.pattern})")
+
+    if total_changed_lines > SMALL_CHANGE_LINE_THRESHOLD:
+        return ReviewDecision(
+            True, f"{total_changed_lines} changed line(s) exceeds the small-change threshold ({SMALL_CHANGE_LINE_THRESHOLD})"
+        )
+
+    return ReviewDecision(
+        False, f"{total_changed_lines} changed line(s), no risk pattern matched — mechanical checks are enough"
+    )

--- a/ampower_koda/agent/checks.py
+++ b/ampower_koda/agent/checks.py
@@ -21,7 +21,7 @@ import subprocess
 import frappe
 
 from ampower_koda.agent.tools import _resolve_path, validate_code
-from ampower_koda.agent.git_ops import diff_file
+from ampower_koda.agent.git_ops import diff_file_working_tree
 
 REQUIRED_DOCTYPE_KEYS = ("doctype", "name", "module")
 REQUIRED_REPORT_KEYS = ("doctype", "report_name", "ref_doctype")
@@ -308,24 +308,20 @@ class ReviewDecision:
 def needs_llm_review(app_name: str, base_branch: str, branch_name: str, edits: list[dict]) -> ReviewDecision:
     """Decide whether mechanical checks passing is enough, or an LLM should
     still look at this change.
-
-    Only ``.py`` edits are considered for size/risk — pure JSON/JS-only
-    changes are already fully covered by the mechanical checks (JSON
-    validity + the wiring check), so they never need this at all.
+    
     """
     py_paths = [e.get("path", "") for e in (edits or []) if (e.get("path") or "").endswith(".py")]
     if not py_paths:
         return ReviewDecision(False, "no Python changes — mechanical checks cover this fully")
 
-    if not branch_name:
-        # No branch to diff against yet (e.g. edits not committed) — cannot
-        # measure size/risk safely, so fail toward the LLM rather than
-        # silently skipping a change we couldn't actually inspect.
-        return ReviewDecision(True, "no branch available to diff — cannot assess size/risk")
+    if not base_branch:
+        # No base to diff against — cannot measure size/risk safely, so
+        # fail toward the LLM rather than silently assuming the change is safe.
+        return ReviewDecision(True, "no base branch available to diff — cannot assess size/risk")
 
     total_changed_lines = 0
     for path in py_paths:
-        ok, diff_text = diff_file(app_name, base_branch, branch_name, path)
+        ok, diff_text = diff_file_working_tree(app_name, base_branch, path)
         if not ok:
             # Can't get a diff for this file — same reasoning as above,
             # don't guess that it's safe.

--- a/ampower_koda/agent/git_ops.py
+++ b/ampower_koda/agent/git_ops.py
@@ -323,6 +323,21 @@ def diff_file(
     return ok, out
 
 
+def diff_file_working_tree(app_name: str, base_branch: str, file_path: str) -> tuple[bool, str]:
+    """Unified diff for a single file between base_branch and the current
+    working tree (uncommitted changes included).
+    """
+    if not file_path:
+        return False, ""
+    root = get_repo_root(app_name)
+    base = (base_branch or "main").strip()
+    ok, out = run_git_stdout(
+        ["diff", base, "--", file_path],
+        cwd=root,
+    )
+    return ok, out
+
+
 def checkout_base(app_name: str, base_branch: str = "main") -> tuple[bool, str]:
     """
     Discards all uncommitted changes and returns the repository to its 

--- a/ampower_koda/agent/graph.py
+++ b/ampower_koda/agent/graph.py
@@ -18,6 +18,7 @@ from ampower_koda.agent.errors import log_agent_error
 from ampower_koda.agent.state import AgentState
 from ampower_koda.agent import koda_core
 from ampower_koda.agent import tools as agent_tools
+from ampower_koda.agent.checks import run_health_checks, needs_llm_review
 from ampower_koda.agent.prompts import (
     get_system_prompt,
     get_understand_system_prompt,
@@ -117,19 +118,69 @@ def _llm_response_text(response) -> str:
 
 
 def _parse_review_verdict(text: str) -> tuple[bool, str]:
-    """Parse explicit review verdict without extra LLM calls."""
-    notes = (text or "").strip()
-    upper = notes.upper()
-    if _re.search(r"REVIEW_PASSED\s*[=:]\s*YES\b", upper):
-        return True, notes
-    if _re.search(r"REVIEW_PASSED\s*[=:]\s*NO\b", upper):
-        return False, notes
-    if "REVIEW_PASSED=YES" in upper or "REVIEW PASSED: YES" in upper:
-        return True, notes
-    if "REVIEW_PASSED=NO" in upper or "REVIEW PASSED: NO" in upper:
-        return False, notes
-    return False, notes or "Review verdict missing explicit REVIEW_PASSED=yes/no."
+    """Parse the review verdict as structured JSON, with a soft-pass fallback.
 
+    Preferred format: {"review_passed": true/false, "issues": ["...", ...]}
+
+    If the model didn't produce valid JSON, this is treated as a formatting
+    slip, not a real failure — by the time review_node calls this, the
+    mechanical health checks have already passed, so an unparseable verdict
+    is far more likely to be "forgot the format" than "found a real problem".
+    A genuine failure must be an *explicit* review_passed: false.
+    """
+    notes = (text or "").strip()
+    payload = _extract_review_json(notes)
+
+    if payload is not None and isinstance(payload.get("review_passed"), bool):
+        passed = payload["review_passed"]
+        issues = payload.get("issues") or []
+        if passed:
+            return True, notes
+        if isinstance(issues, list) and issues:
+            formatted = "\n".join(f"- {issue}" for issue in issues if str(issue).strip())
+            return False, formatted or notes
+        return False, notes or "Review reported issues without details."
+
+    # No parseable, well-formed verdict. Mechanical checks already passed
+    # before this was ever called — don't fail a real run over a formatting
+    # slip. Soft pass, but say plainly that the verdict was unparseable so
+    # it's visible in review_notes rather than silently swallowed.
+    return True, (
+        "Verdict could not be parsed as structured JSON; treated as a soft "
+        f"pass since mechanical checks already passed. Raw response: {notes[:300]}"
+    )
+
+
+def _extract_review_json(text: str) -> dict | None:
+    """Pull a {"review_passed": ...} object out of the model's response.
+
+    Tries, in order: the whole response as JSON, a ```json fenced block,
+    then the last {...} object found anywhere in the text — models
+    sometimes add a sentence of prose before or after the JSON despite
+    being asked not to.
+    """
+    candidates = []
+
+    stripped = text.strip()
+    candidates.append(stripped)
+
+    fence_match = _re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, _re.DOTALL)
+    if fence_match:
+        candidates.append(fence_match.group(1))
+
+    brace_match = _re.search(r"\{[^{}]*\"review_passed\"[^{}]*\}", text, _re.DOTALL)
+    if brace_match:
+        candidates.append(brace_match.group(0))
+
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(parsed, dict) and "review_passed" in parsed:
+            return parsed
+    return None
+    
 
 def _syntax_check_edits(app_name: str, edits: list[dict]) -> tuple[bool, str]:
     """Validate edited .py/.js locally so broken syntax never reaches bench."""
@@ -1200,32 +1251,57 @@ def review_node(state: dict) -> dict:
     logs = _log_stage(state, "Reviewing", "started", "Testing implementation quality")
     edits = state.get("edits_made", [])
     app_name = state.get("target_app_name", "")
-
-    syntax_ok, syntax_report = _syntax_check_edits(app_name, edits)
+    base_branch = state.get("base_branch", "")
+    branch_name = state.get("branch_name", "")
     attempt = (state.get("review_attempts") or 0) + 1
-    if not syntax_ok:
+
+    health = run_health_checks(app_name, edits)
+
+    if not health.passed:
+        # A real, mechanical failure — no ambiguity, no need for an LLM
+        # opinion. Same retry/error semantics as before.
+        report = health.summary()
         updates = {
             "review_passed": False,
-            "review_notes": syntax_report[:1000],
+            "review_notes": report[:1000],
             "review_attempts": attempt,
         }
         logs = _log_stage(
             {**state, "stage_log": logs}, "Reviewing", "completed",
-            f"Testing FAILED (syntax): {syntax_report[:120]}"
+            f"Testing FAILED (health check): {report[:120]}"
         )
         if attempt >= MAX_REVIEW_ATTEMPTS:
-            updates["error"] = f"Syntax errors remain after {attempt} test attempt(s)."
+            updates["error"] = f"Health checks failed after {attempt} test attempt(s)."
         updates["stage_log"] = logs
         return updates
 
-    prompt = get_review_prompt(edits, state.get("user_message", ""), request_name=state.get("request_name"))
-    if syntax_report:
-        short_report = "\n".join(syntax_report.splitlines()[:6])
-        prompt += (
-            "\n\n## LOCAL SYNTAX PRE-CHECK (already passed)\n"
-            f"{short_report}\n"
-            "Do not re-run validate_code unless you need to re-check after reasoning."
+    decision = needs_llm_review(app_name, base_branch, branch_name, edits)
+    if not decision.needs_llm:
+        # Checks passed, and the change is small/low-risk enough that a
+        # model's judgment isn't worth the tokens for this run.
+        updates = {
+            "review_passed": True,
+            "review_notes": f"Mechanical checks passed; LLM review skipped ({decision.reason}).",
+            "review_attempts": attempt,
+        }
+        logs = _log_stage(
+            {**state, "stage_log": logs}, "Reviewing", "completed",
+            f"Testing PASSED (mechanical only — {decision.reason})"
         )
+        updates["stage_log"] = logs
+        return updates
+
+    # Checks passed, but size/risk says this is worth a model's attention —
+    # run the existing LLM review, informed by what's already been verified
+    # so it doesn't spend rounds re-checking syntax/JSON/imports/wiring.
+    prompt = get_review_prompt(edits, state.get("user_message", ""), request_name=state.get("request_name"))
+    short_report = "\n".join(health.summary().splitlines()[:6])
+    prompt += (
+        "\n\n## LOCAL HEALTH CHECKS (already passed)\n"
+        f"{short_report}\n"
+        f"## WHY THIS NEEDS REVIEW\n{decision.reason}\n"
+        "Do not re-verify syntax, JSON validity, imports, or wiring — focus on logic and quality."
+    )
     updates = _run_agent_turn(state, "Reviewing", prompt, read_only_tools=True, max_rounds=MAX_TOOL_ROUNDS_REVIEW)
     if updates.get("error"):
         logs = _log_stage({**state, "stage_log": logs}, "Reviewing", "failed", updates["error"][:200])

--- a/ampower_koda/agent/prompts.py
+++ b/ampower_koda/agent/prompts.py
@@ -542,11 +542,13 @@ meets Frappe standards. Keep this review brief and focused.
 6. **Style** — consistent naming, no dead code, no unused imports.
 
 ### Verdict format (REQUIRED)
-- All good: `REVIEW_PASSED=yes`
-- Issues found: `REVIEW_PASSED=no` then list each issue:
-  - File: path — Issue: ... — Fix: ...
+Output ONLY a single JSON object, nothing before or after it:
+{{"review_passed": true, "issues": []}}
 
-After reading the files, output the verdict immediately.
+If issues were found:
+{{"review_passed": false, "issues": ["File: path — Issue: ... — Fix: ...", "..."]}}
+
+After reading the files, output the verdict JSON immediately — no prose before or after it.
 """
     template = get_config_prompt("review_prompt", default, request_name)
     context = {


### PR DESCRIPTION
## Summary
Fixes two review-stage bugs from the Phase 3 doc — Bug 1 ("Testing" is mostly AI opinion, not real checks) and Bug 4 (missing review verdict treated as failure). Both live in the same stage, so they're combined here.

## Bug 1 — Testing was AI opinion only, not real Frappe checks

- Added `agent/checks.py` — 4 real mechanical checks run before any LLM call: syntax, DocType/Report/Page JSON validity, import smoke test, client↔server wiring
- Any check failure now fails the run immediately with a specific mechanical reason — no LLM call wasted rediscovering it
- Added `needs_llm_review()` — skips the LLM entirely when checks pass and the change is small (≤25 changed lines) and risk-free (no raw SQL, `subprocess`, `eval`, permission bypass, secrets, etc. on an added line); pure JSON/JS-only changes always skip
- Uncertain cases (no branch to diff, unreadable diff) always fail toward running the LLM, never toward silently skipping
- Testing on real branches caught and fixed two real issues: risk-pattern matching against context lines (false trigger), and an indentation bug risking `UnboundLocalError` on rename-only diffs

## Bug 4 — missing exact verdict phrase treated as failure

- Changed the review prompt to request structured JSON (`{"review_passed": true, "issues": []}`) instead of the exact literal string `REVIEW_PASSED=yes/no`
- Rewrote `_parse_review_verdict` to parse JSON, with a new `_extract_review_json` trying 3 formats: raw JSON, fenced block, or JSON embedded in prose
- Unparseable verdicts are now a **soft pass**, not a hard fail — since Bug 1's mechanical checks already passed by that point, a formatting miss shouldn't fail the whole run
- Raw response is always kept in `review_notes`, so a soft pass is still visible, not hidden
- Verified with 9 test cases in `bench console` (clean JSON, fenced, in-prose, no-JSON-at-all, empty, explicit fail, malformed) — all correct